### PR TITLE
#22383 add swiss resolutions to map.custom.js.dist

### DIFF
--- a/extract/src/main/resources/static/js/requestMap/map.custom.js.dist
+++ b/extract/src/main/resources/static/js/requestMap/map.custom.js.dist
@@ -55,7 +55,8 @@ function initializeMap() {
                 ],
                 target: 'orderMap',
                 view : new ol.View({
-                    projection: swissProjection
+                    projection: swissProjection,
+                    resolutions: [650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5, 0.25, 0.1]
                 })
             }));
 


### PR DESCRIPTION
https://projets.asitvd.ch/issues/22383

---

Ajout des résolutions dans la vue OpenLayers:

Afin d'utiliser les tuiles WMTS de façon optimales, il est nécessaire de définir en plus de la projection, les résolutions de la vue.

En me basant sur la doc pour le WMTS 2056 [1], les valeurs sont les suivantes :

resolutions: [650, 500, 250, 100, 50, 20, 10, 5, 2.5, 2, 1, 0.5, 0.25, 0.1]

A ajouter dans le fichier map.custom.js.dist

[1] https://api3.geo.admin.ch/services/sdiservices.html#gettile
