### PR TITLE
FIX #315 in map.custom.js.dist

### DIFF
--- a/extract/src/main/resources/static/js/requestMap/map.custom.js.dist
+++ b/extract/src/main/resources/static/js/requestMap/map.custom.js.dist
@@ -19,11 +19,11 @@
 function initializeMap() {
     return new Promise(function(resolve, reject) {
         proj4.defs('EPSG:2056', '+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs ');
-        ol.proj.setProj4(proj4);
+        ol.proj.proj4.register(proj4);
 
         var swissProjection = ol.proj.get('EPSG:2056');
 
-        fetch('https://ows.asitvd.ch/wmts/GetCapabilities').then(function(response) {
+        fetch('https://wmts.asit-asso.ch/wmts/GetCapabilities').then(function(response) {
             return response.text();
 
         }).then(function(capabilitiesText) {
@@ -33,7 +33,7 @@ function initializeMap() {
                 layer: 'asitvd.fond_couleur',
                 matrixSet: '2056'
             });
-            options.attributions = 'géodonnées © Etat de Vaud & © contributeurs OpenStreetMap';
+            options.attributions = 'Géodonnées © Office fédéral de topographie swisstopo & © contributeurs OpenStreetMap';
 
             const attribution = new ol.control.Attribution({
                 collapsible: true,
@@ -43,7 +43,7 @@ function initializeMap() {
 
             resolve(new ol.Map({
                 controls: ol.control.defaults.defaults({attribution: false}).extend([attribution]),
-                ayers : [
+                layers : [
                     new ol.layer.Tile({
                         source: new ol.source.WMTS(options),
                         title: 'Fond ASIT VD - couleur',
@@ -51,11 +51,11 @@ function initializeMap() {
                     }),
                     new ol.layer.Image({
                         source: new ol.source.ImageWMS({
-                            attributions: 'géodonnées © Etat de Vaud - Informations dépourvues de foi publique',
+                            attributions: 'Géodonnées © Office fédéral de topographie swisstopo - Informations dépourvues de foi publique',
                             params: {
-                                'LAYERS': 'vd.commune'
+                                'LAYERS': 'ch.swisstopo.swissboundaries3d-gemeinde-flaeche.fill'
                             },
-                            url: 'http://wms.vd.ch/public/services/wmsVD/Mapserver/Wmsserver'
+                            url: 'https://wms.geo.admin.ch'
                         }),
                         title: 'Communes',
                     })


### PR DESCRIPTION
FIX #315

Dans le fichier d'exemple map.custom.js.dist, suite à la mise à jour d'Openlayers (Extract v2.1), il y a :
- une typo (ayers -> layers)
- le chargement de Porj4js a changé

Au passage je mets à jour le WMTS ASIT et je passe sur les sources libres de swisstopo pour le WMS