### PR TITLE
fix #350: remove unused paramInputData=SourceDataset_FILEGDB from FME config

### DIFF
--- a/changelog/v2.4/ISSUE_350.md
+++ b/changelog/v2.4/ISSUE_350.md
@@ -1,0 +1,30 @@
+# ISSUE_350 - Retirer le paramètre paramInputData=SourceDataset_FILEGDB
+
+## Status: ✅ CONFORME
+
+### Issue Description
+Le paramètre `paramInputData=SourceDataset_FILEGDB` du fichier
+`extract-task-fmedesktop/src/main/resources/plugins/fme/properties/configFME.properties`
+était inutilisé et devait être retiré.
+
+### Conformity Analysis
+**CONFORME** - Vérification effectuée : la propriété `paramInputData` n'est consommée par
+aucun code de l'application. Elle n'était référencée que par le fichier `.properties`
+lui-même et par un test unitaire qui en assertait la valeur.
+
+### Implementation Completed
+1. Suppression de la ligne `paramInputData=SourceDataset_FILEGDB` dans `configFME.properties`.
+2. Suppression du test devenu obsolète `returnsParamInputDataProperty`
+   (`PluginConfigurationTest`).
+
+### Tests
+Aucun nouveau test : il s'agit d'un retrait de configuration inutilisée. Le test couvrant
+la propriété supprimée a été retiré ; le reste de `PluginConfigurationTest` continue de
+couvrir les propriétés effectivement utilisées.
+
+### Impact documentation / i18n
+Aucun : la propriété n'apparaît pas dans la documentation d'architecture et ne correspond
+à aucun libellé multilingue.
+
+### Conclusion
+Le paramètre inutilisé est retiré sans impact sur le comportement de l'application.

--- a/extract-task-fmedesktop/src/main/resources/plugins/fme/properties/configFME.properties
+++ b/extract-task-fmedesktop/src/main/resources/plugins/fme/properties/configFME.properties
@@ -11,4 +11,3 @@ paramRequestOrderLabel=OrderLabel
 paramRequestInternalId=Request
 paramRequestClientGuid=Client
 paramRequestOrganismGuid=Organism
-paramInputData=SourceDataset_FILEGDB

--- a/extract-task-fmedesktop/src/test/java/ch/asit_asso/extract/plugins/fmedesktop/PluginConfigurationTest.java
+++ b/extract-task-fmedesktop/src/test/java/ch/asit_asso/extract/plugins/fmedesktop/PluginConfigurationTest.java
@@ -173,15 +173,6 @@ public class PluginConfigurationTest {
         }
 
         @Test
-        @DisplayName("Returns paramInputData property")
-        void returnsParamInputDataProperty() {
-            String value = configuration.getProperty("paramInputData");
-
-            assertNotNull(value);
-            assertEquals("SourceDataset_FILEGDB", value);
-        }
-
-        @Test
         @DisplayName("Returns null for non-existent property")
         void returnsNullForNonExistentProperty() {
             String value = configuration.getProperty("nonexistent.property");


### PR DESCRIPTION
Closes #350.

Removes the `paramInputData=SourceDataset_FILEGDB` entry from `extract-task-fmedesktop/src/main/resources/plugins/fme/properties/configFME.properties`.

This property is not consumed anywhere in the application code — it was only referenced by the properties file itself and a unit test asserting its value. The corresponding test (`returnsParamInputDataProperty`) is removed as well.

Milestone: v2.4.0