### PR TITLE
fix #355: add Utilisateurs navigation button on user groups page

### DIFF
--- a/changelog/v2.4/ISSUE_355.md
+++ b/changelog/v2.4/ISSUE_355.md
@@ -1,0 +1,29 @@
+# ISSUE_355 - Bouton de navigation manquant sur la page des groupes
+
+## Status: ✅ CONFORME
+
+### Issue Description
+Sur la page de gestion des groupes (`/userGroups`), il manquait un bouton « Utilisateurs »
+permettant de revenir à la page « Utilisateurs et droits ». La page utilisateurs dispose
+déjà d'un bouton « Groupes » symétrique ; la navigation n'était possible que dans un sens
+sans repasser par le menu.
+
+### Acceptance Criteria
+| Identifiant | Description |
+| --- | --- |
+| 355-1 | Le nouveau bouton est implémenté comme dans la maquette et est fonctionnel (allers/retours possibles entre groupes et utilisateurs sans passer par le menu) |
+
+### Implementation Completed
+1. Ajout d'un bouton « Utilisateurs » dans `templates/pages/userGroups/list.html`, pointant
+   vers `/users`, calqué sur le bouton « Groupes » existant de la page utilisateurs
+   (style `btn-extract-white`, icône `fa-user`).
+2. Externalisation du libellé via la nouvelle clé i18n `userGroupsList.users.button`,
+   disponible en **français** (Utilisateurs), **allemand** (Benutzer) et anglais (Users).
+
+### Tests
+- `UserGroupManagementIntegrationTest` : nouveau test `5.1b` vérifiant que la page
+  `/userGroups` rend bien le bouton de navigation vers `/users`.
+
+### Conclusion
+Le critère 355-1 est satisfait : la navigation aller/retour entre groupes et utilisateurs
+est possible sans passer par le menu.

--- a/extract/src/main/resources/messages_de.properties
+++ b/extract/src/main/resources/messages_de.properties
@@ -507,6 +507,7 @@ userGroupDetails.page.title.edit=Bearbeitung der Benutzergruppe "{0}"
 #User groups list page
 userGroupsList.body.title=Benutzergruppen
 userGroupsList.new.button=Neue Gruppe
+userGroupsList.users.button=Benutzer
 userGroupsList.buttons.delete.active.tooltip=Diese Gruppe löschen
 userGroupsList.buttons.delete.inactive.tooltip=Diese Gruppe kann nicht gelöscht werden, da sie mindestens einer Verarbeitung zugewiesen ist.
 userGroupsList.errors.userGroup.delete.failed=Bei der Löschung der Benutzergruppe ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.

--- a/extract/src/main/resources/messages_en.properties
+++ b/extract/src/main/resources/messages_en.properties
@@ -503,6 +503,7 @@ userGroupDetails.page.title.edit=Editing user group "{0}"
 #User groups list page
 userGroupsList.body.title=User groups
 userGroupsList.new.button=New group
+userGroupsList.users.button=Users
 userGroupsList.buttons.delete.active.tooltip=Delete this group
 userGroupsList.buttons.delete.inactive.tooltip=This group cannot be deleted because it is assigned to at least one process.
 userGroupsList.errors.userGroup.delete.failed=An error occurred while deleting the user group. Please try again later.

--- a/extract/src/main/resources/messages_fr.properties
+++ b/extract/src/main/resources/messages_fr.properties
@@ -506,6 +506,7 @@ userGroupDetails.page.title.edit=\u00c9dition du groupe d'utilisateurs "{0}"
 #User groups list page
 userGroupsList.body.title=Groupes d'utilisateurs
 userGroupsList.new.button=Nouveau groupe
+userGroupsList.users.button=Utilisateurs
 userGroupsList.buttons.delete.active.tooltip=Supprimer ce groupe
 userGroupsList.buttons.delete.inactive.tooltip=Ce groupe ne peut pas \u00eatre supprim\u00e9 car il est affect\u00e9 \u00e0 au moins un traitement.
 userGroupsList.errors.userGroup.delete.failed=Une erreur s'est produite lors de la suppression du groupe d'utilisateurs. Veuillez r\u00e9essayer plus tard.

--- a/extract/src/main/resources/templates/pages/userGroups/list.html
+++ b/extract/src/main/resources/templates/pages/userGroups/list.html
@@ -12,6 +12,11 @@
         <div id="wrapper">
             <div id="page-wrapper" layout:fragment="content">
                 <div class="btn-group float-end">
+                    <a class="btn btn-extract-white btn-md" href="../users"
+                       th:href="@{/users}">
+                        <i class="fa fa-user fa-fw"></i>
+                        <span th:text="#{userGroupsList.users.button}">{Users}</span>
+                    </a>
                     <a class="btn btn-extract-filled btn-md" href="add"
                        th:href="@{/userGroups/add}">
                         <i class="fa fa-plus fa-fw"></i>

--- a/extract/src/main/resources/templates/pages/userGroups/list.html
+++ b/extract/src/main/resources/templates/pages/userGroups/list.html
@@ -11,7 +11,7 @@
     <body>
         <div id="wrapper">
             <div id="page-wrapper" layout:fragment="content">
-                <div class="btn-group float-end">
+                <div class="float-end">
                     <a class="btn btn-extract-white btn-md" href="../users"
                        th:href="@{/users}">
                         <i class="fa fa-user fa-fw"></i>

--- a/extract/src/test/java/ch/asit_asso/extract/integration/users/UserGroupManagementIntegrationTest.java
+++ b/extract/src/test/java/ch/asit_asso/extract/integration/users/UserGroupManagementIntegrationTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -457,6 +458,18 @@ class UserGroupManagementIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(view().name("userGroups/list"))
                 .andExpect(model().attributeExists("userGroups"));
+        }
+
+        @Test
+        @DisplayName("5.1b - Group list shows a navigation button back to the users page (issue #355)")
+        @WithMockApplicationUser(username = "admin", userId = 2, role = "ADMIN")
+        void groupListShowsUsersNavigationButton() throws Exception {
+            mockMvc.perform(get("/userGroups"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("userGroups/list"))
+                // The white button is unique to this navigation link (not used in the layout/menu)
+                .andExpect(content().string(containsString("btn-extract-white")))
+                .andExpect(content().string(containsString("href=\"/users\"")));
         }
 
         @Test


### PR DESCRIPTION
Closes #355.

Adds a **Utilisateurs / Users / Benutzer** navigation button on the user groups page (`/extract/userGroups`), mirroring the existing **Groupes** button on the users page. This allows going back and forth between groups and users without using the main menu (acceptance criterion 355-1).

Changes:
- `userGroups/list.html`: new `btn-extract-white` button linking to `/users`.
- New i18n key `userGroupsList.users.button` in fr / en / de.

Milestone: v2.4.0