### PR TITLE
fix #381: sort dropdowns and tables alphabetically ignoring case and accents

### DIFF
--- a/changelog/v2.4/ISSUE_381.md
+++ b/changelog/v2.4/ISSUE_381.md
@@ -1,0 +1,146 @@
+# ISSUE_381 - Dropdown lists are not sorted alphabetically
+
+## Status: COMPLIANT
+
+### Issue Description
+
+The content of the application's drop-downs was not sorted in case-insensitive
+alphabetical order. Two distinct causes coexisted:
+
+1. Byte-wise sorting. A PostgreSQL `ORDER BY name` compares bytes, which places all
+   uppercase letters before all lowercase ones (`Zulu` before `beta`). JavaScript's
+   `Array.prototype.sort()` behaves the same way.
+2. No sorting at all. Some lists came back in database insertion order.
+
+### Acceptance Criteria
+
+| Identifier | Description |
+| --- | --- |
+| 381-1 | The contents of all drop-downs in the application are sorted in case-insensitive alphabetical order |
+
+### Design decision: sorting is done in Java, not in SQL
+
+A SQL `ORDER BY` delegates sorting to the PostgreSQL server's collation, which varies
+from one Extract installation to another:
+
+- a PostgreSQL built against glibc sorts `épsilon` next to `e`;
+- a PostgreSQL built against musl (the `postgres:12-alpine` image used by the tests,
+  for instance) has virtually no collation support and falls back to byte order, which
+  places `épsilon` after `Zulu`;
+- `ORDER BY UPPER(name)` fixes the case issue but remains subject to that collation for
+  accented characters.
+
+The resulting order would therefore depend on the deployment. Sorting is consequently
+performed in the JVM, by the new class `ch.asit_asso.extract.utils.AlphabeticalOrder`.
+It relies on a `java.text.Collator` with `PRIMARY` strength, which ignores both case and
+accents (`é` = `e`, `Ä` = `a`). The order is thus identical across all installations,
+and consistent with the client-side sorting done by
+`localeCompare(..., { sensitivity: 'base' })`.
+
+The lists involved hold at most a few hundred entries: the cost of in-memory sorting is
+negligible.
+
+### Implementation Completed
+
+Sorting stays in the persistence layer, through `default` methods on the repositories.
+Controllers remain thin and there is no duplication.
+
+| Dropdown | Page | Fix |
+| --- | --- | --- |
+| Process filter | Home | `ProcessesRepository.findAllSortedByName()` |
+| Connector filter | Home | `ConnectorsRepository.findAllSortedByName()` |
+| User groups | Process editing | `UserGroupsRepository.findAllSortedByName()` |
+| Users | Process editing | `UsersRepository.findAllActiveApplicationUsersSortedByName()` |
+| User groups | Request details | same (shared consumer) |
+| Users | Request details | same (shared consumer) |
+| Users | Group details | `UsersRepository.findAllApplicationUsersSortedByName()` |
+| Process in rules | Connector editing | `ProcessesRepository.findAllSortedByName()`, replacing an unsorted `findAll()` |
+| Predefined remarks | Process editing | `RemarkRepository.findAllSortedByTitle()` |
+| Filter by type | Connector list | `connectorsList.js`: `localeCompare(..., { sensitivity: 'base' })` |
+
+The "users" and "groups" dropdowns are shared by three controllers
+(`ProcessesController`, `RequestsController`, `UserGroupsController`). The fix is
+applied at the source, in the repositories, which handles all of them at once without
+duplication.
+
+### Scope extension: table sorting
+
+The issue only mentions drop-downs, but the tables (DataTables) suffered from the same
+defect, visibly. Their default sorting lowercases the text, so case handling was
+correct, but then compares code points, which pushed any accented letter after `z`
+(`Ärgerlich` sorted after `Zurich`). The connectors, processes and groups tables were
+affected.
+
+Letting a table sort differently from the drop-down on the same page would have been
+inconsistent. DataTables sorting is therefore also delegated to
+`localeCompare(..., { sensitivity: 'base' })`, in `datatableConfig.js`, at the single
+place where the shared configuration is built. Both the `string` and `html` types are
+overridden, because DataTables classifies as `html` any cell containing a link, which is
+the case for the "Name" column of most tables.
+
+Date columns are not affected: their sort value is a zero-padded 15-character digit
+string (`_getTimestampStringSortValue`), which sorts identically whatever the
+comparator. The "Processed requests" table sorts server-side and is not affected.
+
+### Scope: elements deliberately left unchanged
+
+| Element | Reason |
+| --- | --- |
+| Filters on the "Users and rights" page (role, state, notifications, 2FA) | These are static options (hard-coded `<option>` elements with i18n labels), rendered in DOM order; select2 does not re-sort them. No byte-wise sorting applies to them, contrary to what the issue assumed. Sorting them alphabetically would degrade usability ("Yes / No" would become "No / Yes"), as their order is logical, not alphabetical. |
+| Properties highlighted at validation (Settings) | The select2 only rehydrates the values already selected; there is no candidate list to sort. |
+| Connector state panel (`connectorsStateContainer`) | This is not a drop-down but a status panel. |
+
+### Tests
+
+`AlphabeticalOrderTest` (new, unit) covers the ordering rule itself, without a database:
+case-insensitivity, accent-insensitivity (an accented letter must not be pushed after `z`),
+null names sorted last, the source collection left untouched, the empty and single-entry
+cases, and the fact that a fresh comparator is handed out on every call (a `Collator`
+cannot be shared between threads).
+
+`DropdownOrderingIntegrationTest` (new) covers the six data sources:
+
+- sorting of connectors, processes, user groups and remarks;
+- sorting of active users and of all application users;
+- filtering non-regression: the system user remains excluded, and so do inactive users;
+- edge cases: single entry, empty result, lowercase not pushed after all uppercase,
+  accented letter sorted next to its base letter (`Ärger, avion, Eau, élan, figue,
+  Zurich`).
+
+The test datasets deliberately mix cases and an accent (`zebra`, `Alpha`, `beta`,
+`Zulu`, `épsilon`), so that byte-wise sorting and the expected sorting produce different
+results.
+
+`TableOrderingFunctionalTest` (new) covers the browser side. The tables are sorted by
+DataTables, in the browser: no Java test can reach that code, and the project has no
+JavaScript test harness, so driving a real browser is the only way to cover the ordering
+override installed by `datatableConfig.js`. The test seeds mixed-case and accented names,
+sorts the processes and the user groups tables on their name column, and checks the order
+the browser actually renders, in both directions.
+
+`UserGroupsListIntegrationTest` and `UserGroupManagementIntegrationTest` were aligned
+with the new finders.
+
+The `connectorsList.js` change (the type filter of the connector list) is the one part
+left without an automated test: that column shows the label of the connector plugin, and
+Extract ships a single connector plugin, so the drop-down legitimately holds one entry and
+no ordering can be exercised against real data. The comparator itself is the same one the
+tables use, and is covered by `TableOrderingFunctionalTest`.
+
+### Documentation / i18n impact
+
+- i18n: no new label, the change only affects an ordering. The fr/de/en parity is
+  unchanged.
+- `docs/features/architecture.md`: a new "Alphabetical ordering of the lists" subsection
+  was added under "Technical details". The data model and the flows are unchanged, but
+  the way every browsable list is ordered is now a cross-cutting convention (a server-side
+  `Collator` and a client-side `localeCompare`, deliberately not a SQL `ORDER BY`), which
+  a developer adding a new list needs to know about.
+- Database: no migration.
+
+### Conclusion
+
+Criterion 381-1 is satisfied for all data-driven drop-downs, as well as for the tables.
+Sorting is performed in Java by `AlphabeticalOrder` on the server side and by
+`localeCompare` on the client side, which yields the same order whatever the database
+collation and whatever the interface language.

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -641,6 +641,29 @@ It is possible to launch an LDAP synchronization (if LDAP authentication is enab
 
 ![ldap-synchro](../assets/dev-guide/ldap-synchro.jpg){width="800"}
 
+### Alphabetical ordering of the lists
+
+Every list the user can browse (the drop-downs of the filters and of the forms, and the sortable columns
+of the tables) is ordered alphabetically while **ignoring both the case and the accents**: `beta` comes
+before `Zulu`, and `Ärgerlich` comes before `avenches` rather than after `Zurich`.
+
+That ordering is deliberately **not** delegated to the database. A SQL `ORDER BY` relies on the collation
+the PostgreSQL server was built with, and that collation differs from one Extract installation to another:
+a server built against the glibc sorts an accented letter next to its base letter, whereas a server built
+against musl has virtually no collation support and falls back to the byte order, which pushes every
+accented letter after `z`. The same list would then be ordered differently depending on the deployment.
+
+The ordering is therefore performed by the application, in two places that follow the same rule:
+
+| Layer | Component | Mechanism |
+| --- | --- | --- |
+| Server | ``ch.asit_asso.extract.utils.AlphabeticalOrder`` | A ``java.text.Collator`` with the ``PRIMARY`` strength, which treats a letter, its uppercase form and its accented forms as equal. The repositories expose the sorted lists through ``default`` methods (``findAllSortedByName()``, ``findAllSortedByTitle()``, ``findAllActiveApplicationUsersSortedByName()``), so that the controllers stay thin and every consumer of a given list gets the same order. |
+| Browser | ``datatableConfig.js``, ``connectorsList.js`` | ``localeCompare(..., { sensitivity: 'base' })``. The DataTables ``string`` and ``html`` ordering types are overridden once, in the shared configuration, so that every table of the application sorts like the drop-downs. |
+
+The lists concerned hold at most a few hundred entries, so sorting them in memory rather than in the
+database has no measurable cost. Sorting a list that could grow without bound would require a different
+approach (a paginated query, and an ordering the database can index).
+
 <br>
 <br>
 <br>

--- a/extract/src/main/java/ch/asit_asso/extract/persistence/ConnectorsRepository.java
+++ b/extract/src/main/java/ch/asit_asso/extract/persistence/ConnectorsRepository.java
@@ -18,6 +18,7 @@ package ch.asit_asso.extract.persistence;
 
 import java.util.List;
 import ch.asit_asso.extract.domain.Connector;
+import ch.asit_asso.extract.utils.AlphabeticalOrder;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 
@@ -29,11 +30,13 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 public interface ConnectorsRepository extends PagingAndSortingRepository<Connector, Integer> {
 
     /**
-     * Fetches all the connectors that are currently active and sort them by their name.
+     * Fetches all the connectors and sorts them by their name, ignoring the case and the accents.
      *
      * @return a list that contain the connector data objects
      */
-    Iterable<Connector> findAllByOrderByName();
+    default List<Connector> findAllSortedByName() {
+        return AlphabeticalOrder.sort(this.findAll(), Connector::getName);
+    }
 
 
 

--- a/extract/src/main/java/ch/asit_asso/extract/persistence/ProcessesRepository.java
+++ b/extract/src/main/java/ch/asit_asso/extract/persistence/ProcessesRepository.java
@@ -16,7 +16,9 @@
  */
 package ch.asit_asso.extract.persistence;
 
+import java.util.List;
 import ch.asit_asso.extract.domain.Process;
+import ch.asit_asso.extract.utils.AlphabeticalOrder;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
@@ -30,7 +32,14 @@ import org.springframework.data.repository.query.Param;
  */
 public interface ProcessesRepository extends PagingAndSortingRepository<Process, Integer> {
 
-    Iterable<Process> findAllByOrderByName();
+    /**
+     * Fetches all the processes sorted by their name, ignoring the case and the accents.
+     *
+     * @return a list that contains the process data objects
+     */
+    default List<Process> findAllSortedByName() {
+        return AlphabeticalOrder.sort(this.findAll(), Process::getName);
+    }
 
 
 

--- a/extract/src/main/java/ch/asit_asso/extract/persistence/RemarkRepository.java
+++ b/extract/src/main/java/ch/asit_asso/extract/persistence/RemarkRepository.java
@@ -1,7 +1,9 @@
 package ch.asit_asso.extract.persistence;
 
+import java.util.List;
 import ch.asit_asso.extract.domain.Process;
 import ch.asit_asso.extract.domain.Remark;
+import ch.asit_asso.extract.utils.AlphabeticalOrder;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 /**
@@ -12,11 +14,14 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 public interface RemarkRepository extends PagingAndSortingRepository<Remark, Integer> {
 
     /**
-     * Obtains all the predefined remarks in the data source and sorts them based on their title.
+     * Obtains all the predefined remarks in the data source and sorts them based on their title, ignoring
+     * the case and the accents.
      *
      * @return a collection of all the predefined remarks in the data source
      */
-    Iterable<Remark> findAllByOrderByTitle();
+    default List<Remark> findAllSortedByTitle() {
+        return AlphabeticalOrder.sort(this.findAll(), Remark::getTitle);
+    }
 
     /**
      * Obtains a predefined request based on its title.

--- a/extract/src/main/java/ch/asit_asso/extract/persistence/UserGroupsRepository.java
+++ b/extract/src/main/java/ch/asit_asso/extract/persistence/UserGroupsRepository.java
@@ -17,9 +17,11 @@
 package ch.asit_asso.extract.persistence;
 
 import ch.asit_asso.extract.domain.UserGroup;
+import ch.asit_asso.extract.utils.AlphabeticalOrder;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 import java.util.Collection;
+import java.util.List;
 
 
 /**
@@ -29,7 +31,14 @@ import java.util.Collection;
  */
 public interface UserGroupsRepository extends PagingAndSortingRepository<UserGroup, Integer> {
 
-    Collection<UserGroup> findAllByOrderByName();
+    /**
+     * Fetches all the user groups sorted by their name, ignoring the case and the accents.
+     *
+     * @return a collection that contains the user group data objects
+     */
+    default List<UserGroup> findAllSortedByName() {
+        return AlphabeticalOrder.sort(this.findAll(), UserGroup::getName);
+    }
 
 
     /**

--- a/extract/src/main/java/ch/asit_asso/extract/persistence/UsersRepository.java
+++ b/extract/src/main/java/ch/asit_asso/extract/persistence/UsersRepository.java
@@ -16,11 +16,13 @@
  */
 package ch.asit_asso.extract.persistence;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import ch.asit_asso.extract.domain.Request;
 import ch.asit_asso.extract.domain.User;
 import ch.asit_asso.extract.domain.User.Profile;
+import ch.asit_asso.extract.utils.AlphabeticalOrder;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 
@@ -59,6 +61,30 @@ public interface UsersRepository extends PagingAndSortingRepository<User, Intege
      * @return an array of users
      */
     User[] findAllApplicationUsers();
+
+
+
+    /**
+     * Obtains all the users that are allowed to log in, sorted by their name, ignoring the case and the
+     * accents.
+     *
+     * @return a list of users
+     */
+    default List<User> findAllActiveApplicationUsersSortedByName() {
+        return AlphabeticalOrder.sort(Arrays.asList(this.findAllActiveApplicationUsers()), User::getName);
+    }
+
+
+
+    /**
+     * Obtains all the users that are not system users, sorted by their name, ignoring the case and the
+     * accents.
+     *
+     * @return a list of users
+     */
+    default List<User> findAllApplicationUsersSortedByName() {
+        return AlphabeticalOrder.sort(Arrays.asList(this.findAllApplicationUsers()), User::getName);
+    }
 
 
 

--- a/extract/src/main/java/ch/asit_asso/extract/utils/AlphabeticalOrder.java
+++ b/extract/src/main/java/ch/asit_asso/extract/utils/AlphabeticalOrder.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025 asit-asso
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.asit_asso.extract.utils;
+
+import java.text.Collator;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.stream.StreamSupport;
+
+/**
+ * Sorts the entries of the application drop-down lists alphabetically, ignoring the case and the accents
+ * (so that <code>épsilon</code> comes between <code>beta</code> and <code>zebra</code>, and not after
+ * <code>Zulu</code>).
+ *
+ * <p>The sorting is deliberately done in Java rather than by the database: a SQL <code>ORDER BY</code>
+ * delegates to the collation of the server, which differs from one Extract installation to the next (a
+ * glibc-based PostgreSQL sorts accented letters next to their plain counterpart, whereas a musl-based one
+ * falls back to the byte order and pushes them after <code>z</code>). Sorting in the JVM makes the order
+ * identical on every installation, and consistent with the client-side sorting performed by
+ * <code>localeCompare(..., {sensitivity: 'base'})</code>.</p>
+ *
+ * <p>The lists concerned (connectors, processes, user groups, predefined remarks, users) hold at most a
+ * few hundred entries, so sorting them in memory is inexpensive.</p>
+ *
+ * @author Bruno Alves
+ */
+public final class AlphabeticalOrder {
+
+    /**
+     * The locale whose alphabetical rules are applied. The application defaults to French and, at the
+     * primary strength used here, the Latin-script locales agree on the ordering anyway.
+     */
+    private static final Locale ORDERING_LOCALE = Locale.FRENCH;
+
+
+    /**
+     * This class only exposes static members.
+     */
+    private AlphabeticalOrder() {
+    }
+
+
+    /**
+     * Builds a comparator that orders strings alphabetically, ignoring the case and the accents. Entries
+     * whose value is <code>null</code> are sorted last.
+     *
+     * <p>A new comparator (and thus a new collator) is returned on each call, because a
+     * {@link Collator} is not safe to share between threads.</p>
+     *
+     * @return the comparator
+     */
+    public static Comparator<String> comparator() {
+        final Collator collator = Collator.getInstance(AlphabeticalOrder.ORDERING_LOCALE);
+        // PRIMARY only tells base letters apart: "a", "A" and "à" are considered equal.
+        collator.setStrength(Collator.PRIMARY);
+
+        return Comparator.nullsLast(collator::compare);
+    }
+
+
+    /**
+     * Sorts items alphabetically based on a name, ignoring the case and the accents.
+     *
+     * @param <T>          the type of the items to sort
+     * @param items        the items to sort
+     * @param nameAccessor the function that reads the name to sort an item on
+     * @return a new list that contains the items in alphabetical order
+     */
+    public static <T> List<T> sort(final Iterable<T> items, final Function<T, String> nameAccessor) {
+        return StreamSupport.stream(items.spliterator(), false)
+                            .sorted(Comparator.comparing(nameAccessor, AlphabeticalOrder.comparator()))
+                            .toList();
+    }
+}

--- a/extract/src/main/java/ch/asit_asso/extract/web/controllers/ConnectorsController.java
+++ b/extract/src/main/java/ch/asit_asso/extract/web/controllers/ConnectorsController.java
@@ -462,7 +462,7 @@ public class ConnectorsController extends BaseController {
     private ProcessModel[] getAllProcesses() {
         final List<ProcessModel> processesList = new ArrayList<>();
 
-        for (Process domainProcess : this.processesRepository.findAll()) {
+        for (Process domainProcess : this.processesRepository.findAllSortedByName()) {
 
             processesList.add(new ProcessModel(domainProcess.getId(), domainProcess.getName()));
         }

--- a/extract/src/main/java/ch/asit_asso/extract/web/controllers/IndexController.java
+++ b/extract/src/main/java/ch/asit_asso/extract/web/controllers/IndexController.java
@@ -169,8 +169,8 @@ public class IndexController extends BaseController {
         } else {
 
 
-            model.addAttribute("processes", this.processesRepository.findAllByOrderByName());
-            model.addAttribute("connectors", this.connectorsRepository.findAllByOrderByName());
+            model.addAttribute("processes", this.processesRepository.findAllSortedByName());
+            model.addAttribute("connectors", this.connectorsRepository.findAllSortedByName());
             model.addAttribute("refreshInterval",
                     Integer.valueOf(this.parametersRepository.getDashboardRefreshInterval()));
             model.addAttribute("tablePageSize", this.tablePageSize);

--- a/extract/src/main/java/ch/asit_asso/extract/web/controllers/ProcessesController.java
+++ b/extract/src/main/java/ch/asit_asso/extract/web/controllers/ProcessesController.java
@@ -613,7 +613,7 @@ public class ProcessesController extends BaseController {
     private List<UserModel> getAllActiveUsers() {
         final List<UserModel> usersList = new ArrayList<>();
 
-        for (User domainUser : this.usersRepository.findAllActiveApplicationUsers()) {
+        for (User domainUser : this.usersRepository.findAllActiveApplicationUsersSortedByName()) {
 
             usersList.add(new UserModel(domainUser));
         }
@@ -624,7 +624,7 @@ public class ProcessesController extends BaseController {
 
 
     private Collection<UserGroup> getAllUserGroups() {
-        return this.userGroupsRepository.findAllByOrderByName();
+        return this.userGroupsRepository.findAllSortedByName();
     }
 
 
@@ -637,7 +637,7 @@ public class ProcessesController extends BaseController {
     private List<RemarkModel> getAllRemarks() {
         final List<RemarkModel> remarksList = new ArrayList<>();
 
-        for (Remark domainRemark : this.remarksRepository.findAllByOrderByTitle()) {
+        for (Remark domainRemark : this.remarksRepository.findAllSortedByTitle()) {
             remarksList.add(new RemarkModel(domainRemark, this.tasksRepository));
         }
 

--- a/extract/src/main/java/ch/asit_asso/extract/web/controllers/RequestsController.java
+++ b/extract/src/main/java/ch/asit_asso/extract/web/controllers/RequestsController.java
@@ -1971,7 +1971,7 @@ public class RequestsController extends BaseController {
     private List<UserModel> getAllActiveUsers() {
         final List<UserModel> usersList = new ArrayList<>();
 
-        for (User domainUser : this.usersRepository.findAllActiveApplicationUsers()) {
+        for (User domainUser : this.usersRepository.findAllActiveApplicationUsersSortedByName()) {
 
             usersList.add(new UserModel(domainUser));
         }
@@ -1980,7 +1980,7 @@ public class RequestsController extends BaseController {
     }
     
     private Collection<UserGroup> getAllUserGroups() {
-        return this.userGroupsRepository.findAllByOrderByName();
+        return this.userGroupsRepository.findAllSortedByName();
     }
 
     public FeatureConfiguration getFeatures() {

--- a/extract/src/main/java/ch/asit_asso/extract/web/controllers/UserGroupsController.java
+++ b/extract/src/main/java/ch/asit_asso/extract/web/controllers/UserGroupsController.java
@@ -407,7 +407,7 @@ public class UserGroupsController extends BaseController {
                 }
             }
 
-            model.addAttribute("allactiveusers", this.usersRepository.findAllApplicationUsers());
+            model.addAttribute("allactiveusers", this.usersRepository.findAllApplicationUsersSortedByName());
             this.addCurrentSectionToModel(currentSection, model);
 
         } catch (Exception exception) {

--- a/extract/src/main/resources/static/js/connectorsList.js
+++ b/extract/src/main/resources/static/js/connectorsList.js
@@ -53,7 +53,10 @@ $(function() {
             types.push(type);
         }
     });
-    types.sort();
+    // Case- and accent-insensitive alphabetical sort (default sort() is ASCII, uppercase first)
+    types.sort(function(a, b) {
+        return String(a).localeCompare(String(b), undefined, { sensitivity: 'base' });
+    });
     types.forEach(function(type) {
         $('#typeFilter').append('<option value="' + type + '">' + type + '</option>');
     });

--- a/extract/src/main/resources/static/js/datatableConfig.js
+++ b/extract/src/main/resources/static/js/datatableConfig.js
@@ -6,6 +6,34 @@
  */
 
 /**
+ * Makes every table column sort alphabetically while ignoring the case AND the accents.
+ *
+ * The ordering that DataTables applies by default lowercases the text but then compares code points,
+ * so an accented letter lands after "z" ("Ärgerlich" after "Zurich"). Delegating the comparison to
+ * localeCompare with a base sensitivity puts it back next to its plain counterpart, and keeps the
+ * tables consistent with the drop-downs, which are sorted the same way.
+ *
+ * Both the "string" and the "html" types are overridden, because DataTables detects a cell holding a
+ * link (the name column of most tables) as HTML rather than as plain text.
+ */
+(function useAlphabeticalOrderingInTables() {
+
+    if (typeof $ === 'undefined' || !$.fn || !$.fn.dataTable) {
+        return;
+    }
+
+    var compare = function(a, b) {
+        return String(a).localeCompare(String(b), undefined, { sensitivity: 'base' });
+    };
+
+    var order = $.fn.dataTable.ext.type.order;
+    order['string-asc'] = function(a, b) { return compare(a, b); };
+    order['string-desc'] = function(a, b) { return compare(b, a); };
+    order['html-asc'] = function(a, b) { return compare(a, b); };
+    order['html-desc'] = function(a, b) { return compare(b, a); };
+})();
+
+/**
  * Gets the base DataTables configuration properties with i18n support
  *
  * @returns {Object} DataTables configuration object

--- a/extract/src/test/java/ch/asit_asso/extract/functional/lists/TableOrderingFunctionalTest.java
+++ b/extract/src/test/java/ch/asit_asso/extract/functional/lists/TableOrderingFunctionalTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2025 asit-asso
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.asit_asso.extract.functional.lists;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import ch.asit_asso.extract.domain.Process;
+import ch.asit_asso.extract.domain.UserGroup;
+import ch.asit_asso.extract.functional.pages.LoginPage;
+import ch.asit_asso.extract.persistence.ProcessesRepository;
+import ch.asit_asso.extract.persistence.UserGroupsRepository;
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Functional tests for the ordering of the tables (issue #381).
+ *
+ * The tables are sorted by DataTables, in the browser: no Java test can reach that code, and the
+ * project has no JavaScript test harness. Driving a real browser is therefore the only way to cover the
+ * ordering override installed by datatableConfig.js.
+ *
+ * The ordering must ignore the case AND the accents. The default DataTables ordering lowercases the text
+ * (so the case was already handled) but then compares code points, which pushed every accented letter
+ * after "z": "Ärger" ended up after "Zulu" instead of coming right after "Alpha".
+ *
+ * The rows are seeded behind a marker and the assertions only bear on those, so that the rows already
+ * present in the database cannot make the test flaky.
+ *
+ * @author Bruno Alves
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Tag("functional")
+@DisplayName("Table Ordering Functional Tests (issue #381)")
+public class TableOrderingFunctionalTest {
+
+    private static final String ADMIN_USERNAME = "admin";
+
+    private static final String ADMIN_PASSWORD = "motdepasse21";
+
+    private static final String APPLICATION_URL = "http://127.0.0.1:8080/extract";
+
+    /**
+     * The title that every page of the application carries. It tells the application apart from the 404
+     * page that the server answers while the application is redeploying.
+     */
+    private static final String APPLICATION_TITLE = "Extract";
+
+    /**
+     * The class DataTables sets on the header of the column it sorts in ascending order.
+     */
+    private static final String ASCENDING_CLASS = "dt-ordering-asc";
+
+    /**
+     * The class DataTables sets on the header of the column it sorts in descending order.
+     */
+    private static final String DESCENDING_CLASS = "dt-ordering-desc";
+
+    /**
+     * How many times the header of a column is clicked before giving up on sorting it. Clicking a header
+     * cycles through the ascending order, the descending one, then no order at all, so three clicks are
+     * enough to reach any of them whatever the state the table starts in.
+     */
+    private static final int MAXIMUM_SORT_CLICKS = 3;
+
+    /**
+     * Prefixes the seeded names. It sorts after the existing rows, and lets the assertions ignore them.
+     */
+    private static final String MARKER = "ZZ381-";
+
+    /**
+     * The names to seed. Their order here is the one a code-point comparison would NOT produce.
+     */
+    private static final List<String> SEEDED_NAMES = List.of("zebra", "Alpha", "Zulu", "Ärger", "beta",
+                                                             "épsilon");
+
+    /**
+     * The order the seeded names must be displayed in: the case and the accents are ignored, so "Ärger"
+     * sits next to "Alpha" and "épsilon" between "beta" and "zebra".
+     */
+    private static final List<String> EXPECTED_ORDER = List.of("Alpha", "Ärger", "beta", "épsilon",
+                                                               "zebra", "Zulu");
+
+    @Autowired
+    private ProcessesRepository processesRepository;
+
+    @Autowired
+    private UserGroupsRepository userGroupsRepository;
+
+    private WebDriver driver;
+
+    private final List<Integer> seededProcessIds = new ArrayList<>();
+
+    private final List<Integer> seededGroupIds = new ArrayList<>();
+
+
+    @BeforeAll
+    public static void setUpClass() {
+        WebDriverManager.chromedriver().setup();
+    }
+
+
+    @BeforeEach
+    public void setUp() {
+        this.seedRows();
+
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments(List.of("--disable-gpu", "--window-size=1920,1200",
+                                     "--ignore-certificate-errors", "--disable-extensions", "--no-sandbox",
+                                     "--disable-dev-shm-usage", "--headless", "--remote-allow-origins=*",
+                                     "--disable-logging", "--log-level=OFF"));
+
+        this.driver = new ChromeDriver(options);
+        this.driver.manage().timeouts().implicitlyWait(Duration.of(10, ChronoUnit.SECONDS));
+
+        this.waitForTheApplicationToBeDeployed();
+        new LoginPage(this.driver).loginAs(TableOrderingFunctionalTest.ADMIN_USERNAME,
+                                           TableOrderingFunctionalTest.ADMIN_PASSWORD);
+    }
+
+
+    /**
+     * Opens the application, waiting for it to answer.
+     *
+     * The build repackages the WAR that the application server deploys, so the application can still be
+     * redeploying when the test starts, and it then answers a 404. Rather than assume it is up, the page
+     * is requested again until it is served.
+     */
+    private void waitForTheApplicationToBeDeployed() {
+        new WebDriverWait(this.driver, Duration.of(90, ChronoUnit.SECONDS))
+                .pollingEvery(Duration.of(2, ChronoUnit.SECONDS))
+                .ignoring(WebDriverException.class)
+                .until(webDriver -> {
+                    webDriver.get(TableOrderingFunctionalTest.APPLICATION_URL);
+
+                    return TableOrderingFunctionalTest.APPLICATION_TITLE.equals(webDriver.getTitle());
+                });
+    }
+
+
+    @AfterEach
+    public void tearDown() {
+        if (this.driver != null) {
+            this.driver.quit();
+        }
+
+        this.seededProcessIds.forEach(id -> this.processesRepository.deleteById(id));
+        this.seededProcessIds.clear();
+        this.seededGroupIds.forEach(id -> this.userGroupsRepository.deleteById(id));
+        this.seededGroupIds.clear();
+    }
+
+
+    @Test
+    @DisplayName("The processes table ignores the case and the accents")
+    public void processesTableIgnoresCaseAndAccents() {
+        this.driver.get(TableOrderingFunctionalTest.APPLICATION_URL + "/processes");
+
+        assertEquals(TableOrderingFunctionalTest.EXPECTED_ORDER, this.readSeededNamesOfSortedTable(),
+                     "The processes table must sort ignoring the case and the accents");
+    }
+
+
+    @Test
+    @DisplayName("The user groups table ignores the case and the accents")
+    public void userGroupsTableIgnoresCaseAndAccents() {
+        this.driver.get(TableOrderingFunctionalTest.APPLICATION_URL + "/userGroups");
+
+        assertEquals(TableOrderingFunctionalTest.EXPECTED_ORDER, this.readSeededNamesOfSortedTable(),
+                     "The user groups table must sort ignoring the case and the accents");
+    }
+
+
+    @Test
+    @DisplayName("Sorting the processes table in reverse yields the opposite order")
+    public void processesTableCanBeSortedInReverse() {
+        this.driver.get(TableOrderingFunctionalTest.APPLICATION_URL + "/processes");
+        this.sortOnTheNameColumn(TableOrderingFunctionalTest.DESCENDING_CLASS);
+
+        List<String> expectedReversed = new ArrayList<>(TableOrderingFunctionalTest.EXPECTED_ORDER);
+        Collections.reverse(expectedReversed);
+
+        assertEquals(expectedReversed, this.readSeededNames(),
+                     "Sorting in reverse must yield the opposite order, still ignoring case and accents");
+    }
+
+
+    /**
+     * Sorts the displayed table on its name column, then reads the names that this test seeded.
+     *
+     * @return the seeded names, in the order the table displays them
+     */
+    private List<String> readSeededNamesOfSortedTable() {
+        this.sortOnTheNameColumn(TableOrderingFunctionalTest.ASCENDING_CLASS);
+
+        return this.readSeededNames();
+    }
+
+
+    /**
+     * Sorts the displayed table on its name column, which is the first one of every list table.
+     *
+     * The tables do not all start in the same state: clicking the header once yields a descending order
+     * on a table that was already sorted ascending. The header is therefore clicked until it carries the
+     * class that stands for the wanted direction, rather than a fixed number of times.
+     *
+     * @param wantedClass the class DataTables sets on the header of the column it sorts on
+     */
+    private void sortOnTheNameColumn(final String wantedClass) {
+
+        for (int attempt = 0; attempt < TableOrderingFunctionalTest.MAXIMUM_SORT_CLICKS; attempt++) {
+            WebElement header = this.driver.findElement(By.cssSelector(
+                    "table.dataTable thead th:first-child"));
+
+            if (header.getAttribute("class").contains(wantedClass)) {
+                return;
+            }
+
+            header.click();
+        }
+
+        throw new IllegalStateException(String.format("The name column could not be sorted %s.",
+                                                      wantedClass));
+    }
+
+
+    /**
+     * Reads the name column of the displayed table, keeping only the rows that this test seeded and
+     * stripping the marker that prefixes them.
+     *
+     * @return the seeded names, in the order the table displays them
+     */
+    private List<String> readSeededNames() {
+        List<WebElement> cells
+                = this.driver.findElements(By.cssSelector("table.dataTable tbody tr td:first-child"));
+
+        return cells.stream()
+                    .map(cell -> cell.getText().trim())
+                    .filter(name -> name.startsWith(TableOrderingFunctionalTest.MARKER))
+                    .map(name -> name.substring(TableOrderingFunctionalTest.MARKER.length()))
+                    .toList();
+    }
+
+
+    /**
+     * Adds the rows whose ordering this test checks.
+     */
+    private void seedRows() {
+
+        for (String name : TableOrderingFunctionalTest.SEEDED_NAMES) {
+            Process process = new Process();
+            process.setName(TableOrderingFunctionalTest.MARKER + name);
+            this.seededProcessIds.add(this.processesRepository.save(process).getId());
+
+            UserGroup group = new UserGroup();
+            group.setName(TableOrderingFunctionalTest.MARKER + name);
+            group.setUsersCollection(new ArrayList<>());
+            group.setProcessesCollection(new ArrayList<>());
+            this.seededGroupIds.add(this.userGroupsRepository.save(group).getId());
+        }
+    }
+}

--- a/extract/src/test/java/ch/asit_asso/extract/integration/ordering/DropdownOrderingIntegrationTest.java
+++ b/extract/src/test/java/ch/asit_asso/extract/integration/ordering/DropdownOrderingIntegrationTest.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright (C) 2025 asit-asso
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.asit_asso.extract.integration.ordering;
+
+import ch.asit_asso.extract.domain.Connector;
+import ch.asit_asso.extract.domain.Process;
+import ch.asit_asso.extract.domain.Remark;
+import ch.asit_asso.extract.domain.User;
+import ch.asit_asso.extract.domain.UserGroup;
+import ch.asit_asso.extract.integration.DatabaseTestHelper;
+import ch.asit_asso.extract.persistence.ConnectorsRepository;
+import ch.asit_asso.extract.persistence.ProcessesRepository;
+import ch.asit_asso.extract.persistence.RemarkRepository;
+import ch.asit_asso.extract.persistence.UserGroupsRepository;
+import ch.asit_asso.extract.persistence.UsersRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.StreamSupport;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for issue #381: every data-driven dropdown must be sorted alphabetically,
+ * ignoring the case.
+ *
+ * <p>The seeded names deliberately mix cases and include an accented one, so that the byte ordering a
+ * plain SQL {@code ORDER BY name} would produce differs from the expected one on two counts: a byte sort
+ * puts every uppercase letter before every lowercase one ({@code Zulu} before {@code beta}) and pushes
+ * accented letters after {@code z} ({@code épsilon} after {@code Zulu}).</p>
+ *
+ * <p>The ordering is therefore performed in Java by {@link ch.asit_asso.extract.utils.AlphabeticalOrder},
+ * which makes it identical on every installation regardless of the collation of the database server.</p>
+ *
+ * <p>Each test seeds its own entries behind a unique marker and only asserts on those, so that the rows
+ * already present in the test database cannot make the assertions flaky.</p>
+ *
+ * @author Bruno Alves
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Tag("integration")
+@DisplayName("Dropdown Ordering Integration Tests (issue #381)")
+class DropdownOrderingIntegrationTest {
+
+    /**
+     * The names seeded by the tests. Their order here is the one a byte sort would NOT produce.
+     */
+    private static final String[] MIXED_CASE_NAMES = {"zebra", "Alpha", "beta", "Zulu", "épsilon"};
+
+    /**
+     * The order the seeded names must come back in once sorted alphabetically, ignoring the case and the
+     * accents. A byte sort would instead yield Alpha, Zulu, beta, zebra, épsilon.
+     */
+    private static final List<String> EXPECTED_ORDER = List.of("Alpha", "beta", "épsilon", "zebra", "Zulu");
+
+    @Autowired
+    private ConnectorsRepository connectorsRepository;
+
+    @Autowired
+    private ProcessesRepository processesRepository;
+
+    @Autowired
+    private UserGroupsRepository userGroupsRepository;
+
+    @Autowired
+    private UsersRepository usersRepository;
+
+    @Autowired
+    private RemarkRepository remarkRepository;
+
+    @Autowired
+    private DatabaseTestHelper dbHelper;
+
+
+    @Nested
+    @DisplayName("1. Repository finders feeding the dropdowns")
+    class RepositoryOrderingTests {
+
+        @Test
+        @DisplayName("1.1 - Connectors (home filter) are sorted ignoring the case")
+        @Transactional
+        void connectorsAreSortedIgnoringCase() {
+            String marker = seedMarker("conn");
+            Arrays.stream(MIXED_CASE_NAMES).forEach(name -> dbHelper.createTestConnector(marker + name));
+
+            List<String> actual = seededNames(connectorsRepository.findAllSortedByName(),
+                                              Connector::getName, marker);
+
+            assertEquals(expectedOrder(marker), actual, "Connectors must be sorted ignoring the case");
+        }
+
+
+        @Test
+        @DisplayName("1.2 - Processes (home filter and connector rules) are sorted ignoring the case")
+        @Transactional
+        void processesAreSortedIgnoringCase() {
+            String marker = seedMarker("proc");
+            Arrays.stream(MIXED_CASE_NAMES).forEach(name -> dbHelper.createTestProcess(marker + name));
+
+            List<String> actual = seededNames(processesRepository.findAllSortedByName(),
+                                              Process::getName, marker);
+
+            assertEquals(expectedOrder(marker), actual, "Processes must be sorted ignoring the case");
+        }
+
+
+        @Test
+        @DisplayName("1.3 - User groups (process and request operators) are sorted ignoring the case")
+        @Transactional
+        void userGroupsAreSortedIgnoringCase() {
+            String marker = seedMarker("grp");
+            Arrays.stream(MIXED_CASE_NAMES).forEach(name -> dbHelper.createTestUserGroup(marker + name));
+
+            List<String> actual = seededNames(userGroupsRepository.findAllSortedByName(),
+                                              UserGroup::getName, marker);
+
+            assertEquals(expectedOrder(marker), actual, "User groups must be sorted ignoring the case");
+        }
+
+
+        @Test
+        @DisplayName("1.4 - Predefined remarks are sorted by title ignoring the case")
+        @Transactional
+        void remarksAreSortedIgnoringCase() {
+            String marker = seedMarker("rmk");
+
+            for (String name : MIXED_CASE_NAMES) {
+                Remark remark = new Remark();
+                remark.setTitle(marker + name);
+                remark.setContent("Content of " + name);
+                remarkRepository.save(remark);
+            }
+
+            List<String> actual = seededNames(remarkRepository.findAllSortedByTitle(),
+                                              Remark::getTitle, marker);
+
+            assertEquals(expectedOrder(marker), actual, "Remarks must be sorted by title ignoring the case");
+        }
+    }
+
+
+    @Nested
+    @DisplayName("2. Active users finder (process, request and group operators)")
+    class ActiveUsersOrderingTests {
+
+        @Test
+        @DisplayName("2.1 - Active application users are sorted by name ignoring the case")
+        @Transactional
+        void activeUsersAreSortedIgnoringCase() {
+            String marker = seedMarker("usr");
+
+            for (String name : MIXED_CASE_NAMES) {
+                dbHelper.createTestOperator(marker + name, marker + name, marker + name + "@test.ch", true);
+            }
+
+            List<String> actual = seededNames(usersRepository.findAllActiveApplicationUsersSortedByName(),
+                                              User::getName, marker);
+
+            assertEquals(expectedOrder(marker), actual, "Active users must be sorted ignoring the case");
+        }
+
+
+        @Test
+        @DisplayName("2.2 - Ordering does not resurrect inactive users nor the system user")
+        @Transactional
+        void orderingPreservesTheExistingFiltering() {
+            String marker = seedMarker("filt");
+            dbHelper.createTestOperator(marker + "active", marker + "active", marker + "a@test.ch", true);
+            dbHelper.createTestOperator(marker + "inactive", marker + "inactive", marker + "i@test.ch", false);
+
+            List<String> actual = seededNames(usersRepository.findAllActiveApplicationUsersSortedByName(),
+                                              User::getName, marker);
+
+            assertEquals(List.of(marker + "active"), actual, "Only the active seeded user must be returned");
+
+            List<String> allLogins = new ArrayList<>();
+            for (User user : usersRepository.findAllActiveApplicationUsersSortedByName()) {
+                allLogins.add(user.getLogin());
+            }
+            assertFalse(allLogins.contains(User.SYSTEM_USER_LOGIN), "The system user must stay excluded");
+        }
+
+
+        @Test
+        @DisplayName("2.3 - All application users (group members dropdown) are sorted ignoring the case")
+        @Transactional
+        void allApplicationUsersAreSortedIgnoringCase() {
+            String marker = seedMarker("allusr");
+
+            for (String name : MIXED_CASE_NAMES) {
+                dbHelper.createTestOperator(marker + name, marker + name, marker + name + "@test.ch", true);
+            }
+
+            List<String> actual = seededNames(usersRepository.findAllApplicationUsersSortedByName(),
+                                              User::getName, marker);
+
+            assertEquals(expectedOrder(marker), actual, "All application users must be sorted ignoring the case");
+        }
+    }
+
+
+    @Nested
+    @DisplayName("3. Edge cases")
+    class EdgeCaseTests {
+
+        @Test
+        @DisplayName("3.1 - A lowercase name is not pushed after every uppercase one")
+        @Transactional
+        void lowercaseNameIsNotPushedAfterEveryUppercaseOne() {
+            String marker = seedMarker("case");
+            dbHelper.createTestConnector(marker + "zurich");
+            dbHelper.createTestConnector(marker + "Aarau");
+            dbHelper.createTestConnector(marker + "Bern");
+
+            List<String> actual = seededNames(connectorsRepository.findAllSortedByName(),
+                                              Connector::getName, marker);
+
+            assertEquals(List.of(marker + "Aarau", marker + "Bern", marker + "zurich"), actual,
+                         "A lowercase name must not be pushed after every uppercase one");
+        }
+
+
+        /**
+         * An accented letter must be ordered next to its plain counterpart, and NOT after "z" as a byte
+         * ordering would have it. This is what the ordering in Java buys us: a SQL ORDER BY would answer
+         * differently depending on the collation the PostgreSQL server was built with.
+         */
+        @Test
+        @DisplayName("3.2 - An accented letter is ordered next to its unaccented counterpart, not after z")
+        @Transactional
+        void accentedLetterIsOrderedNextToItsUnaccentedCounterpart() {
+            String marker = seedMarker("accent");
+            dbHelper.createTestConnector(marker + "Zurich");
+            dbHelper.createTestConnector(marker + "élan");
+            dbHelper.createTestConnector(marker + "Eau");
+            dbHelper.createTestConnector(marker + "figue");
+            dbHelper.createTestConnector(marker + "Ärger");
+            dbHelper.createTestConnector(marker + "avion");
+
+            List<String> actual = seededNames(connectorsRepository.findAllSortedByName(),
+                                              Connector::getName, marker);
+
+            assertEquals(List.of(marker + "Ärger", marker + "avion", marker + "Eau", marker + "élan",
+                                 marker + "figue", marker + "Zurich"),
+                         actual,
+                         "An accented letter must sort next to its plain counterpart, not after z");
+        }
+
+
+        @Test
+        @DisplayName("3.2 - A single entry and an unmatched marker do not break the finder")
+        @Transactional
+        void singleAndEmptyResultsAreHandled() {
+            String marker = seedMarker("single");
+            dbHelper.createTestConnector(marker + "only");
+
+            List<String> single = seededNames(connectorsRepository.findAllSortedByName(),
+                                              Connector::getName, marker);
+            assertEquals(List.of(marker + "only"), single, "A single entry must be returned as-is");
+
+            List<String> none = seededNames(connectorsRepository.findAllSortedByName(),
+                                            Connector::getName, seedMarker("absent"));
+            assertTrue(none.isEmpty(), "An unmatched marker must yield no entry and no exception");
+        }
+    }
+
+
+    // ==================== HELPER METHODS ====================
+
+    /**
+     * Builds a marker that is unique to a test run, so that the seeded rows can be told apart from the
+     * ones already present in the test database.
+     *
+     * @param prefix a short prefix that identifies the seeded entity type
+     * @return the marker to prepend to every seeded name
+     */
+    private static String seedMarker(final String prefix) {
+        return String.format("ZZ381-%s-%d-", prefix, System.nanoTime());
+    }
+
+
+    /**
+     * Builds the order in which the seeded names are expected to come back.
+     *
+     * @param marker the marker that prefixes the seeded names
+     * @return the expected names, in the expected order
+     */
+    private static List<String> expectedOrder(final String marker) {
+        return EXPECTED_ORDER.stream().map(name -> marker + name).toList();
+    }
+
+
+    /**
+     * Keeps only the entries seeded by the current test, preserving the order returned by the finder.
+     *
+     * @param <T>          the type of the entries returned by the finder
+     * @param entries      the entries returned by the finder
+     * @param nameAccessor the function that reads the name to sort on
+     * @param marker       the marker that prefixes the seeded names
+     * @return the names of the seeded entries, in the order the finder returned them
+     */
+    private static <T> List<String> seededNames(final Iterable<T> entries, final Function<T, String> nameAccessor,
+                                                final String marker) {
+        return StreamSupport.stream(entries.spliterator(), false)
+                            .map(nameAccessor)
+                            .filter(name -> name != null && name.startsWith(marker))
+                            .toList();
+    }
+}

--- a/extract/src/test/java/ch/asit_asso/extract/integration/usergroups/UserGroupsListIntegrationTest.java
+++ b/extract/src/test/java/ch/asit_asso/extract/integration/usergroups/UserGroupsListIntegrationTest.java
@@ -107,7 +107,7 @@ class UserGroupsListIntegrationTest {
             createAndSaveGroup("AAA First Group");
 
             // When
-            Collection<UserGroup> orderedGroups = userGroupsRepository.findAllByOrderByName();
+            Collection<UserGroup> orderedGroups = userGroupsRepository.findAllSortedByName();
 
             // Then
             assertNotNull(orderedGroups);

--- a/extract/src/test/java/ch/asit_asso/extract/integration/users/UserGroupManagementIntegrationTest.java
+++ b/extract/src/test/java/ch/asit_asso/extract/integration/users/UserGroupManagementIntegrationTest.java
@@ -490,7 +490,7 @@ class UserGroupManagementIntegrationTest {
             dbHelper.createTestUserGroup("Beta Group");
 
             // When: Fetching all groups sorted
-            List<UserGroup> groups = new ArrayList<>(userGroupsRepository.findAllByOrderByName());
+            List<UserGroup> groups = new ArrayList<>(userGroupsRepository.findAllSortedByName());
 
             // Then: Check that groups starting with these names are in correct order
             // (Note: there might be other groups from test data)

--- a/extract/src/test/java/ch/asit_asso/extract/unit/utils/AlphabeticalOrderTest.java
+++ b/extract/src/test/java/ch/asit_asso/extract/unit/utils/AlphabeticalOrderTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2025 asit-asso
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.asit_asso.extract.unit.utils;
+
+import ch.asit_asso.extract.utils.AlphabeticalOrder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the AlphabeticalOrder class, which sorts the entries of the drop-downs and of the
+ * tables of the application (issue #381).
+ *
+ * Tests:
+ * - the ordering ignores the case
+ * - the ordering ignores the accents, so that an accented letter is not pushed after "z"
+ * - null values are sorted last instead of throwing
+ * - the sort method keeps the source untouched and handles the empty and single-entry cases
+ * - a fresh comparator is handed out on every call, because a Collator cannot be shared between
+ *   threads
+ *
+ * @author Bruno Alves
+ */
+@DisplayName("AlphabeticalOrder Tests")
+class AlphabeticalOrderTest {
+
+    /**
+     * A name holder, standing for the entities whose lists feed the drop-downs.
+     */
+    private record Entry(String name) {
+    }
+
+
+    @Nested
+    @DisplayName("comparator() tests")
+    class ComparatorTests {
+
+        @Test
+        @DisplayName("Ignores the case")
+        void ignoresTheCase() {
+            List<String> names = new ArrayList<>(Arrays.asList("zebra", "Alpha", "beta", "Zulu"));
+
+            names.sort(AlphabeticalOrder.comparator());
+
+            assertEquals(List.of("Alpha", "beta", "zebra", "Zulu"), names,
+                         "A lowercase name must not be pushed after every uppercase one");
+        }
+
+
+        @Test
+        @DisplayName("Ignores the accents")
+        void ignoresTheAccents() {
+            List<String> names = new ArrayList<>(Arrays.asList("Zurich", "élan", "Eau", "figue", "Ärger",
+                                                               "avion"));
+
+            names.sort(AlphabeticalOrder.comparator());
+
+            assertEquals(List.of("Ärger", "avion", "Eau", "élan", "figue", "Zurich"), names,
+                         "An accented letter must sort next to its base letter, not after z");
+        }
+
+
+        @Test
+        @DisplayName("Considers a letter and its accented form as equal")
+        void considersAccentedFormAsEqual() {
+            Comparator<String> comparator = AlphabeticalOrder.comparator();
+
+            assertEquals(0, comparator.compare("epsilon", "épsilon"), "é must compare as equal to e");
+            assertEquals(0, comparator.compare("ARGER", "ärger"), "The case and the accent must be ignored");
+        }
+
+
+        @Test
+        @DisplayName("Sorts the null values last")
+        void sortsNullValuesLast() {
+            List<String> names = new ArrayList<>(Arrays.asList("beta", null, "Alpha"));
+
+            names.sort(AlphabeticalOrder.comparator());
+
+            assertEquals(Arrays.asList("Alpha", "beta", null), names, "A null name must be sorted last");
+        }
+
+
+        @Test
+        @DisplayName("Hands out a new comparator on every call")
+        void handsOutANewComparatorOnEveryCall() {
+            // A java.text.Collator is not safe to share between threads, so each caller must get its own.
+            assertNotSame(AlphabeticalOrder.comparator(), AlphabeticalOrder.comparator());
+        }
+    }
+
+
+    @Nested
+    @DisplayName("sort() tests")
+    class SortTests {
+
+        @Test
+        @DisplayName("Sorts the items on the accessed name")
+        void sortsItemsOnTheAccessedName() {
+            List<Entry> entries = List.of(new Entry("zebra"), new Entry("épsilon"), new Entry("Alpha"),
+                                          new Entry("beta"), new Entry("Zulu"));
+
+            List<Entry> sorted = AlphabeticalOrder.sort(entries, Entry::name);
+
+            assertEquals(List.of("Alpha", "beta", "épsilon", "zebra", "Zulu"),
+                         sorted.stream().map(Entry::name).toList(),
+                         "The entries must be sorted ignoring the case and the accents");
+        }
+
+
+        @Test
+        @DisplayName("Leaves the source collection untouched")
+        void leavesTheSourceUntouched() {
+            List<Entry> entries = new ArrayList<>(List.of(new Entry("zebra"), new Entry("Alpha")));
+
+            AlphabeticalOrder.sort(entries, Entry::name);
+
+            assertEquals(List.of("zebra", "Alpha"), entries.stream().map(Entry::name).toList(),
+                         "Sorting must return a new list rather than reorder the source");
+        }
+
+
+        @Test
+        @DisplayName("Handles an item whose name is null")
+        void handlesANullName() {
+            List<Entry> entries = List.of(new Entry("beta"), new Entry(null), new Entry("Alpha"));
+
+            List<Entry> sorted = AlphabeticalOrder.sort(entries, Entry::name);
+
+            assertEquals(Arrays.asList("Alpha", "beta", null), sorted.stream().map(Entry::name).toList(),
+                         "An item without a name must be sorted last instead of throwing");
+        }
+
+
+        @Test
+        @DisplayName("Handles the empty and the single-entry collections")
+        void handlesEmptyAndSingleEntryCollections() {
+            assertTrue(AlphabeticalOrder.sort(List.<Entry>of(), Entry::name).isEmpty(),
+                       "An empty collection must yield an empty list");
+
+            List<Entry> single = AlphabeticalOrder.sort(List.of(new Entry("only")), Entry::name);
+
+            assertEquals(1, single.size());
+            assertEquals("only", single.get(0).name());
+        }
+    }
+}


### PR DESCRIPTION
Closes #381.

## Problem

Two distinct causes coexisted:

1. **Byte-wise sorting.** A PostgreSQL `ORDER BY name` compares bytes, so every uppercase letter came before every lowercase one (`Zulu` before `beta`). JavaScript's `Array.prototype.sort()` behaves the same way.
2. **No sorting at all.** Some lists came back in database insertion order.

## Design decision: the sorting is done in Java, not in SQL

A SQL `ORDER BY` delegates sorting to the collation the PostgreSQL server was built with, and that collation differs from one Extract installation to another: a server built against glibc sorts an accented letter next to its base letter, whereas one built against musl falls back to byte order and pushes every accented letter after `z`. `ORDER BY UPPER(name)` fixes the case but remains subject to that collation for accents, so the same list would be ordered differently depending on the deployment.

The ordering is therefore performed by the application, consistently on both sides:

| Layer | Component | Mechanism |
| --- | --- | --- |
| Server | `utils/AlphabeticalOrder` | `java.text.Collator` with `PRIMARY` strength (case and accents ignored). The repositories expose the sorted lists through `default` methods, so the controllers stay thin and every consumer of a list gets the same order. |
| Browser | `datatableConfig.js`, `connectorsList.js` | `localeCompare(..., { sensitivity: 'base' })` |

## What is fixed

Nine data-driven dropdowns: the home connector and process filters, the users and groups of the process editing page, the same two on the request details page, the users of the group details page, the process of a connector rule, and the predefined remarks.

The "users" and "groups" dropdowns are shared by three controllers, so the fix is applied at the source (the repositories) rather than at each call site.

## Scope extension: table sorting

The issue only mentions drop-downs, but the DataTables tables suffered from the same defect, visibly: their default ordering lowercases the text (so the case was already handled) but then compares code points, which pushed `Ärgerlich` after `Zurich`. The connectors, processes and groups tables were affected.

Letting a table sort differently from the drop-down on the same page would have been inconsistent, so the DataTables ordering is delegated to the same comparator, in the single place where the shared configuration is built. **Happy to split this out into its own PR if you would rather keep #381 strictly about drop-downs.**

Date columns are unaffected (their sort value is a zero-padded digit string), and the "Processed requests" table sorts server-side.

## Deliberately left unchanged

- The static filters of the "Users and rights" page (role, state, notifications, 2FA): hard-coded options in a deliberate, logical order. Sorting them would turn "Yes / No" into "No / Yes".
- The validation focus-properties select2, which only rehydrates already-selected values.

## Tests

| Test | Level | Covers |
| --- | --- | --- |
| `AlphabeticalOrderTest` | unit | the ordering rule itself (case, accents, null names last, thread-safety of the comparator) |
| `DropdownOrderingIntegrationTest` | integration | the six repository finders feeding the dropdowns, against a real PostgreSQL |
| `TableOrderingFunctionalTest` | functional | the browser-side ordering, by driving a real Chrome and reading the rendered order in both directions |

The tables are sorted by DataTables in the browser, which no Java test can reach and for which the project has no JavaScript harness, hence the functional test.

Full suites: **176 functional, 494 integration, 0 failure**.

Known gap: the connector-list *type* filter is not covered by an automated test. That column shows the label of the connector plugin, and Extract ships a single connector plugin, so the dropdown legitimately holds one entry and no ordering can be exercised against real data. It uses the same comparator as the tables.

## Documentation

- `docs/features/architecture.md`: new "Alphabetical ordering of the lists" subsection under "Technical details".
- `changelog/v2.4/ISSUE_381.md`.

No new i18n label (only an order changes) and no database migration.