### PR TITLE
fix #425: never write a task that belongs to another process

### DIFF
--- a/changelog/v2.4/ISSUE_425.md
+++ b/changelog/v2.4/ISSUE_425.md
@@ -96,14 +96,29 @@ was removed rather than kept as false evidence. That path is covered by the two 
 on a deployed instance: with the two tasks of a process holding the parameters of other plugins in the database,
 the processes list answers 200 and shows the parameters empty, where it answered 500 before.
 
+### Finding the installations that are already hit
+
+A corrupted task only takes the page down when its plugin has mandatory parameters, as the Python one has. When it
+has none, as the operator validation has, the task keeps working with the settings of another plugin and nothing
+is reported: the corruption is silent. An installation that has never answered a 500 can be affected all the same,
+so the tasks have to be looked at rather than waited for. A task whose stored parameters do not match the ones its
+plugin declares, or a process holding two tasks at the same position, is one of them.
+
+### Repairing by hand
+
+Unchanged: the `tasks` table has to be fixed, as described in the issue. One trap to avoid, met while reproducing
+the bug. Every identifier of the application comes from the same `hibernate_sequence`; giving a repaired row an
+identifier that the sequence has not reached yet makes the next task creation fail on `tasks_pkey`. Reuse an
+identifier that has already been consumed, or move the sequence past the one that was used.
+
 ### Documentation / i18n impact
 
 - i18n: one new key, `processDetails.errors.task.foreign`, in French, German and English.
 - `docs/features/architecture.md`: new "Saving the tasks of a process" subsection, which states the two rules to
   keep (the tag decides what is new, the lookup stays inside the process), what the connector rules do differently,
-  and why positions are not protected by a constraint.
-- Database: no migration. Repairing an installation that was hit still requires fixing the `tasks` table by hand,
-  as described in the issue.
+  why positions are not protected by a constraint, and what the shared sequence implies, both for the collision
+  itself and for anyone repairing rows by hand.
+- Database: no migration.
 
 ### Conclusion
 

--- a/changelog/v2.4/ISSUE_425.md
+++ b/changelog/v2.4/ISSUE_425.md
@@ -109,8 +109,16 @@ plugin declares, or a process holding two tasks at the same position, is one of 
 
 Unchanged: the `tasks` table has to be fixed, as described in the issue. One trap to avoid, met while reproducing
 the bug. Every identifier of the application comes from the same `hibernate_sequence`; giving a repaired row an
-identifier that the sequence has not reached yet makes the next task creation fail on `tasks_pkey`. Reuse an
-identifier that has already been consumed, or move the sequence past the one that was used.
+identifier that the sequence has not reached yet makes the next insertion fail on the primary key, and not
+necessarily in `tasks`. Reuse an identifier that has already been consumed, or move the sequence past the highest
+identifier of **every** table that draws from it.
+
+`sql/create_test_data.sql` did that computation over six tables only, leaving out `usergroups`, `rules`,
+`remarks`, `recovery_codes` and `remember_me_tokens`. On a database where one of those holds the highest
+identifier, the seeded sequence was set below it and the next row written there failed on its primary key. The
+five tables are now part of the computation, each guarded by `to_regclass` so the script still runs on a schema
+that lacks one. The value handed to the sequence is unchanged in principle: the highest identifier plus one, taken
+across all of them.
 
 ### Documentation / i18n impact
 

--- a/changelog/v2.4/ISSUE_425.md
+++ b/changelog/v2.4/ISSUE_425.md
@@ -47,7 +47,7 @@ process and adding any task to it is enough, since the temporary identifier of t
 | --- | --- |
 | `web/model/TaskModel.java` | `saveInDataSource()` no longer queries the whole table. A task tagged `ADDED` is always created, with a null identifier so that the sequence assigns a real one; any other task is looked for among the tasks of the process being saved only, and an identifier that is none of them is refused. |
 | `web/model/ProcessModel.java` | New `getForeignTaskIds()`, which reports the submitted identifiers that do not belong to the process. `getTemporaryRuleId()` renamed `getTemporaryTaskId()`, and its comment fixed: it described rules, and claimed the value was ignored on save, which was exactly the bug. |
-| `web/controllers/ProcessesController.java` | The submission is checked before anything is written, so a refused form leaves the data source exactly as it was. |
+| `web/controllers/ProcessesController.java` | The submission is checked before anything is written, when a process is updated **and** when one is created, so a refused form leaves the data source exactly as it was. Creating a process saves its row before its tasks, so without that check a submission claiming an identifier left an empty process behind and answered a 500. |
 | `web/model/PluginItemModel.java` | A stored value that no longer fits the plugin leaves the parameter empty and logs a warning, instead of throwing. A null map of values is accepted as well. |
 | `messages_fr/de/en.properties` | New key `processDetails.errors.task.foreign`. |
 
@@ -84,8 +84,9 @@ still be read. The test hands the foreign task to whoever fetches it by its iden
 lookup makes the test fail.
 
 `ProcessTaskOwnershipIntegrationTest` (new, integration) runs the real controller against PostgreSQL, and covers
-the save path only: the added task does not touch the other process and gets an identifier of its own, and a
-foreign identifier is refused with nothing written.
+the save path only: the added task does not touch the other process and gets an identifier of its own, a foreign
+identifier is refused with nothing written when a process is updated, and creating a process with a task claiming
+an identifier writes neither the process nor the task.
 
 Each of these tests was run against the unpatched code, and each fails there.
 

--- a/changelog/v2.4/ISSUE_425.md
+++ b/changelog/v2.4/ISSUE_425.md
@@ -1,0 +1,111 @@
+# ISSUE_425 - Saving a process could overwrite a task of another process
+
+## Status: COMPLIANT
+
+### Issue Description
+
+Editing a process could overwrite a task of a **different** process. The reported symptoms are two tasks at the
+same position in the other process, a Python task left without its parameters, and the processes page answering a
+500 to every user until the `tasks` table is repaired by hand.
+
+The reported chronology, with real identifiers:
+
+```
+14:10:06  ProcessModel - Adding a task (ID: 1473) at position 6.
+14:10:34  ProcessesController - Updating the process # 1426 has succeeded.
+14:10:34  ERROR ErrorController - java.lang.IllegalArgumentException: The updated data object cannot be null.
+              at PluginItemModelParameter.validateUpdatedValue
+              at PluginItemModel.setParametersValuesFromMap
+              at ProcessModel.fromDomainObjectsCollection
+              at ProcessesController.viewList
+```
+
+### What actually happened
+
+Three defects lined up.
+
+1. **A temporary identifier that looks real.** A task added through the interface is given
+   `ProcessModel.getTemporaryRuleId()`, the highest identifier of the form plus one. For the process 1426 that
+   value was 1473, which is the identifier of the Python task of the process 1629.
+2. **A lookup that ignores the process.** `TaskModel.saveInDataSource()` fetched that identifier with
+   `taskRepository.findById()`, over the whole table, and found the task of the other process.
+   `updateDomainTask()` then wrote the position and the parameters of the added task into it, without touching its
+   `id_process`: the task stayed in the process 1629, at the position of the process 1426, with the parameters of
+   the archive plugin. The task the administrator wanted was never created.
+3. **A display that cannot survive it.** Reading that task back builds its model from the Python plugin, whose
+   `pythonInterpreter` and `pythonScript` parameters are mandatory and no longer stored.
+   `PluginItemModelParameter.validateUpdatedValue()` throws, and since the processes list builds the model of
+   every process, one corrupted task took the whole page down for everyone.
+
+The browser is only one trigger among others. The reproduction done locally needs no tampering at all: creating a
+process and adding any task to it is enough, since the temporary identifier of the first task of a new process is
+1, and a task carrying the identifier 1 exists in any installation whose first task has not been deleted since.
+
+### Implementation Completed
+
+| File | Change |
+| --- | --- |
+| `web/model/TaskModel.java` | `saveInDataSource()` no longer queries the whole table. A task tagged `ADDED` is always created, with a null identifier so that the sequence assigns a real one; any other task is looked for among the tasks of the process being saved only, and an identifier that is none of them is refused. |
+| `web/model/ProcessModel.java` | New `getForeignTaskIds()`, which reports the submitted identifiers that do not belong to the process. `getTemporaryRuleId()` renamed `getTemporaryTaskId()`, and its comment fixed: it described rules, and claimed the value was ignored on save, which was exactly the bug. |
+| `web/controllers/ProcessesController.java` | The submission is checked before anything is written, so a refused form leaves the data source exactly as it was. |
+| `web/model/PluginItemModel.java` | A stored value that no longer fits the plugin leaves the parameter empty and logs a warning, instead of throwing. A null map of values is accepted as well. |
+| `messages_fr/de/en.properties` | New key `processDetails.errors.task.foreign`. |
+
+### Why the save is refused rather than repaired
+
+An identifier that belongs to another process can no longer come from a legitimate action: what makes a task new
+is now its tag. Turning such a block into a new task would hide a submission that cannot be trusted, so it is
+refused, with a message asking to reload the page. The check runs before the first write, so nothing is half
+saved. `TaskModel.saveInDataSource()` refuses it too, so that a caller that skips the check cannot write either.
+
+### Scope: the unique constraint suggested in the issue is deliberately left out
+
+The issue suggests a unique constraint on `(id_process, position)`. It cannot be added as such: the tasks are
+saved one after the other, each in its own transaction, and no transaction spans the loop. Swapping two tasks
+therefore makes them share a position for a moment, which the local reproduction confirms, and a non-deferrable
+constraint would reject a plain reordering. It would also have to be declared on the entity for the test schema
+that Hibernate generates, where only a non-deferrable one can be produced. Making the whole save transactional and
+adding a deferred constraint is a change of its own, worth doing, but not one to slip into a bug fix.
+
+### Scope: connector rules
+
+The rules of a connector are edited through the same mechanism, and `ConnectorsController.updateConnectorRules()`
+does honour the `ADDED` tag, which is why the defect never showed there. It still fetches an existing rule by its
+identifier alone, over the whole table, so a rule of another connector could be moved that way. This is a distinct
+case, **not** covered by this fix: no such incident has been reported and the change belongs to its own commit.
+
+### Tests
+
+`TaskOwnershipTest` (new, unit) covers the model: a task tagged `ADDED` whose identifier is the one of another
+process's task leaves it alone and is saved without an identifier, an untagged foreign identifier is refused
+without any write, a task of the process is still updated in place, `getForeignTaskIds()` reports the foreign
+identifiers and ignores the temporary ones, and a task whose stored parameters are those of another plugin can
+still be read. The test hands the foreign task to whoever fetches it by its identifier alone, so that the old
+lookup makes the test fail.
+
+`ProcessTaskOwnershipIntegrationTest` (new, integration) runs the real controller against PostgreSQL, and covers
+the save path only: the added task does not touch the other process and gets an identifier of its own, and a
+foreign identifier is refused with nothing written.
+
+Each of these tests was run against the unpatched code, and each fails there.
+
+The tolerant read has no integration test on purpose. The task plugins are not discoverable from the context the
+integration tests run in, so a task is dropped before its parameters are ever read: such a test answers 200
+whatever the code does. One was written, an assertion on the rendered page showed it was proving nothing, and it
+was removed rather than kept as false evidence. That path is covered by the two unit tests above, and was checked
+on a deployed instance: with the two tasks of a process holding the parameters of other plugins in the database,
+the processes list answers 200 and shows the parameters empty, where it answered 500 before.
+
+### Documentation / i18n impact
+
+- i18n: one new key, `processDetails.errors.task.foreign`, in French, German and English.
+- `docs/features/architecture.md`: new "Saving the tasks of a process" subsection, which states the two rules to
+  keep (the tag decides what is new, the lookup stays inside the process), what the connector rules do differently,
+  and why positions are not protected by a constraint.
+- Database: no migration. Repairing an installation that was hit still requires fixing the `tasks` table by hand,
+  as described in the issue.
+
+### Conclusion
+
+A process can no longer write into a task that is not its own, a submission that references one is refused before
+anything is saved, and a task whose parameters were corrupted no longer takes the processes page down.

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -602,6 +602,35 @@ orderlabel == “92445” AND perimeter intersects POLYGON((6.82 46.39,6.92 46.3
 orderlabel == “92445” AND parameters.format == “PDF"
 ```
 
+### Saving the tasks of a process
+
+The tasks of a process are edited as blocks of a single form, and the whole form is posted back on every action:
+adding a task, deleting one and reordering them all go through a submission of the page. Each block carries the
+identifier of the task it stands for, in a hidden ``tasks[i].id`` field.
+
+That identifier is **not trustworthy**. A block that has just been added by "Ajouter une tâche" gets a temporary
+identifier from ``ProcessModel.getTemporaryTaskId()``, which is the highest identifier of the form plus one: it is
+only there to tell the blocks apart until they are saved, and it is very likely to be the identifier of a real task
+of another process. A browser restoring a form can also put a value of its own into a field of the same name, the
+forms of two processes being identical.
+
+Two rules follow, and any new code touching this form must keep them:
+
+* what makes a task new is its ``tag`` field, set to ``ADDED``, never its identifier. A task tagged this way is
+  always created, and it is saved with a null identifier so that the sequence assigns a real one;
+* a task that is not tagged is looked for **among the tasks of the edited process only**
+  (``TaskModel.saveInDataSource``), never in the whole table. An identifier that is none of them is refused:
+  ``ProcessesController`` checks the whole submission with ``ProcessModel.getForeignTaskIds()`` before writing
+  anything, so that a rejected form leaves the data source untouched.
+
+The rules of a connector are edited through the same mechanism, and ``ConnectorsController.updateConnectorRules()``
+does honour the ``ADDED`` tag, which is why the defect above never showed there. It still fetches an existing rule
+by its identifier alone, over the whole table: the second rule is **not** enforced on that side.
+
+Positions are not protected by a database constraint. The tasks are saved one after the other, each in its own
+transaction, so a reordering makes two tasks share a position for a moment; a unique constraint on
+``(id_process, position)`` would reject it.
+
 ### Authentication
 
 There are two types of users:

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -631,6 +631,21 @@ Positions are not protected by a database constraint. The tasks are saved one af
 transaction, so a reordering makes two tasks share a position for a moment; a unique constraint on
 ``(id_process, position)`` would reject it.
 
+Every identifier of the application, whatever the table, comes from the same ``hibernate_sequence``. A task, a
+process, a request and a user therefore take their numbers from the same counter, which is why the identifier a
+form makes up lands on an existing row so easily, and on a row of any kind. Duplicating a process puts more rows
+in the range the original's form will make up from, since the copy takes the numbers that immediately follow those
+of the original: its process row first, then its tasks. Whether the made-up value falls on one of those tasks, on
+the copy's process row, or on nothing at all depends on the order the rows were written in. Only the first case
+collides, and it is the one that was reported.
+
+Duplication itself is safe. ``ProcessesController.cloneProcess()`` copies the tasks with ``Task.createCopy()`` and
+writes them straight through the repository, without going through the form model at all.
+
+Anyone repairing tasks by hand must keep the sequence in mind: giving a row an identifier that
+``hibernate_sequence`` has not reached yet makes the next insertion fail on the primary key. Reuse a number that
+has already been consumed, or move the sequence past it.
+
 ### Authentication
 
 There are two types of users:

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -642,9 +642,16 @@ collides, and it is the one that was reported.
 Duplication itself is safe. ``ProcessesController.cloneProcess()`` copies the tasks with ``Task.createCopy()`` and
 writes them straight through the repository, without going through the form model at all.
 
-Anyone repairing tasks by hand must keep the sequence in mind: giving a row an identifier that
-``hibernate_sequence`` has not reached yet makes the next insertion fail on the primary key. Reuse a number that
-has already been consumed, or move the sequence past it.
+Anyone repairing rows by hand must keep the sequence in mind: giving a row an identifier that
+``hibernate_sequence`` has not reached yet makes the next insertion fail on the primary key, whatever the table it
+lands in. Reuse a number that has already been consumed, or move the sequence past the highest identifier of
+**every** table that draws from it, not only of the one being repaired.
+
+``sql/create_test_data.sql`` ends with that computation and is the reference for it: it takes the maximum of
+``users``, ``connectors``, ``processes``, ``tasks``, ``requests``, ``request_history``, ``usergroups``, ``rules``,
+``remarks``, ``recovery_codes`` and ``remember_me_tokens``, and hands the sequence the value that follows. A table
+left out of that list sets the sequence too low and breaks the next insertion in it, so the list has to grow with
+any new entity.
 
 ### Authentication
 

--- a/extract/src/main/java/ch/asit_asso/extract/web/controllers/ProcessesController.java
+++ b/extract/src/main/java/ch/asit_asso/extract/web/controllers/ProcessesController.java
@@ -288,6 +288,16 @@ public class ProcessesController extends BaseController {
                 return this.prepareModelForDetailsView(model, false);
             }
 
+            final Integer[] foreignTaskIds = processModel.getForeignTaskIds(domainProcess);
+
+            if (foreignTaskIds.length > 0) {
+                this.logger.error("Could not update the process {} because the submitted tasks {} are not its own."
+                        + " Nothing has been saved.", domainProcess.getId(), Arrays.toString(foreignTaskIds));
+                this.addStatusMessage(model, "processDetails.errors.task.foreign", MessageType.ERROR);
+
+                return this.prepareModelForDetailsView(model, false);
+            }
+
             this.saveProcessModifications(processModel, domainProcess);
             this.logger.info("Updating the process # {} has succeeded.", domainProcess.getId());
             this.addStatusMessage(redirectAttributes, "processesList.process.updated", MessageType.SUCCESS);

--- a/extract/src/main/java/ch/asit_asso/extract/web/controllers/ProcessesController.java
+++ b/extract/src/main/java/ch/asit_asso/extract/web/controllers/ProcessesController.java
@@ -183,6 +183,16 @@ public class ProcessesController extends BaseController {
             return this.prepareModelForDetailsView(model, true);
         }
 
+        final Integer[] foreignTaskIds = processModel.getForeignTaskIds();
+
+        if (foreignTaskIds.length > 0) {
+            this.logger.error("Could not create the process because the submitted tasks {} claim to exist already."
+                    + " Nothing has been saved.", Arrays.toString(foreignTaskIds));
+            this.addStatusMessage(model, "processDetails.errors.task.foreign", MessageType.ERROR);
+
+            return this.prepareModelForDetailsView(model, true);
+        }
+
         processModel.createInDataSource(this.processesRepository, this.tasksRepository, this.usersRepository,
                                         this.userGroupsRepository);
 

--- a/extract/src/main/java/ch/asit_asso/extract/web/model/PluginItemModel.java
+++ b/extract/src/main/java/ch/asit_asso/extract/web/model/PluginItemModel.java
@@ -126,12 +126,25 @@ public abstract class PluginItemModel {
     /**
      * Defines the values of the non-standard parameters.
      *
-     * @param parametersValuesMap a map containing the parameters values
+     * The values come from the data source, where they may no longer fit what the plugin expects: a task whose
+     * parameters have been overwritten by those of another plugin keeps the values of that other plugin. Such a
+     * value is skipped rather than rejected, so that the item is displayed with an empty parameter that the
+     * administrator can fix, instead of making the whole page fail.
+     *
+     * @param parametersValuesMap a map containing the parameters values, which may be null
      */
     protected final void setParametersValuesFromMap(final Map<String, String> parametersValuesMap) {
+        final Map<String, String> valuesMap = (parametersValuesMap != null) ? parametersValuesMap : Map.of();
 
         for (PluginItemModelParameter parameter : this.getParameters()) {
-            parameter.updateValue(parametersValuesMap.get(parameter.getName()));
+
+            try {
+                parameter.updateValue(valuesMap.get(parameter.getName()));
+
+            } catch (IllegalArgumentException exception) {
+                this.logger.warn("The stored value of the parameter \"{}\" does not fit what the plugin expects."
+                        + " The parameter is left empty so that it can be set again.", parameter.getName());
+            }
         }
 
         this.logger.debug("The non-standard parameters values have been updated from a map.");

--- a/extract/src/main/java/ch/asit_asso/extract/web/model/ProcessModel.java
+++ b/extract/src/main/java/ch/asit_asso/extract/web/model/ProcessModel.java
@@ -489,7 +489,33 @@ public class ProcessModel extends OwnedObjectModel {
             throw new IllegalArgumentException("The process data object cannot be null.");
         }
 
-        final Collection<Task> tasksInDataSource = domainProcess.getTasksCollection();
+        return this.getForeignTaskIds(domainProcess.getTasksCollection());
+    }
+
+
+
+    /**
+     * Obtains the identifiers of the submitted tasks that cannot be, this process not existing yet.
+     *
+     * A process that is being created holds no task, so every submitted task must be a new one. One that claims an
+     * identifier is either a tampered submission or a form that the browser filled with a value of another process
+     * (issue #425).
+     *
+     * @return the identifiers that no task can carry here, empty if the submitted tasks are consistent
+     */
+    public final Integer[] getForeignTaskIds() {
+        return this.getForeignTaskIds((Collection<Task>) null);
+    }
+
+
+
+    /**
+     * Obtains the identifiers of the submitted tasks that are none of the tasks the process holds.
+     *
+     * @param tasksInDataSource the tasks that the process holds, which may be null
+     * @return the identifiers that do not belong to the process
+     */
+    private Integer[] getForeignTaskIds(final Collection<Task> tasksInDataSource) {
         final List<Integer> foreignTaskIds = new ArrayList<>();
 
         for (TaskModel taskModel : this.tasksList) {

--- a/extract/src/main/java/ch/asit_asso/extract/web/model/ProcessModel.java
+++ b/extract/src/main/java/ch/asit_asso/extract/web/model/ProcessModel.java
@@ -212,7 +212,7 @@ public class ProcessModel extends OwnedObjectModel {
         }
         taskToAdd.setPosition(this.tasksList.size() + 1);
         if (TaskModel.TAG_ADDED.equals(taskToAdd.getTag())) {
-            taskToAdd.setId(this.getTemporaryRuleId());
+            taskToAdd.setId(this.getTemporaryTaskId());
         }
         this.logger.debug("Adding a task (ID: {}) at position {}.", taskToAdd.getId(), taskToAdd.getPosition());
 
@@ -222,19 +222,21 @@ public class ProcessModel extends OwnedObjectModel {
 
 
     /**
-     * Provides a temporary identifier for a new rule. This only ensures that the new object has a unique
-     * identifier among the rules for this controller until it is saved. But this value should be ignored when this
-     * rule is persisted. The real identifier should be assigned by the regular means, e.g. database sequence.
+     * Provides a temporary identifier for a task that has just been added.
      *
-     * @return a temporary identifier that is unique among the rules for this connector
+     * This only tells the new task apart from the other tasks of the form until it is saved. It is not the
+     * identifier of a row of the data source, and it may well be the one of a task of another process: what makes
+     * a task new is its {@link TaskModel#TAG_ADDED} tag, never its identifier.
+     *
+     * @return an identifier that is unique among the tasks of this process
      */
-    private int getTemporaryRuleId() {
+    private int getTemporaryTaskId() {
         int maxTaskId = 0;
 
         for (TaskModel task : this.tasksList) {
-            int taskId = task.getId();
+            Integer taskId = task.getId();
 
-            if (taskId > maxTaskId) {
+            if (taskId != null && taskId > maxTaskId) {
                 maxTaskId = taskId;
             }
         }
@@ -466,6 +468,67 @@ public class ProcessModel extends OwnedObjectModel {
         }
 
         return deletedTasks.toArray(Task[]::new);
+    }
+
+
+
+    /**
+     * Obtains the identifiers of the submitted tasks that are not tasks of this process.
+     *
+     * A task that has just been added carries a temporary identifier, which is not looked at here. Any other
+     * identifier must be one of the tasks that this process holds in the data source. When it is not, the
+     * submitted data cannot be trusted: it has either been tampered with, or the browser has filled the form with
+     * a value belonging to another process (issue #425).
+     *
+     * @param domainProcess the data object for this process
+     * @return the identifiers that do not belong to this process, empty if the submitted tasks are consistent
+     */
+    public final Integer[] getForeignTaskIds(final Process domainProcess) {
+
+        if (domainProcess == null) {
+            throw new IllegalArgumentException("The process data object cannot be null.");
+        }
+
+        final Collection<Task> tasksInDataSource = domainProcess.getTasksCollection();
+        final List<Integer> foreignTaskIds = new ArrayList<>();
+
+        for (TaskModel taskModel : this.tasksList) {
+
+            if (taskModel.isNew()) {
+                continue;
+            }
+
+            if (!ProcessModel.containsTask(tasksInDataSource, taskModel.getId())) {
+                foreignTaskIds.add(taskModel.getId());
+            }
+        }
+
+        return foreignTaskIds.toArray(Integer[]::new);
+    }
+
+
+
+    /**
+     * Obtains whether a collection of task data objects holds the one with a given identifier.
+     *
+     * @param domainTasks the task data objects to look into, which may be null
+     * @param taskId      the identifier to look for
+     * @return <code>true</code> if one of those tasks carries that identifier
+     */
+    private static boolean containsTask(final Collection<Task> domainTasks, final Integer taskId) {
+
+        if (domainTasks == null) {
+            return false;
+        }
+
+        for (Task domainTask : domainTasks) {
+
+            if (Objects.equals(domainTask.getId(), taskId)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 

--- a/extract/src/main/java/ch/asit_asso/extract/web/model/TaskModel.java
+++ b/extract/src/main/java/ch/asit_asso/extract/web/model/TaskModel.java
@@ -17,6 +17,7 @@
 package ch.asit_asso.extract.web.model;
 
 import java.util.Arrays;
+import java.util.Objects;
 import ch.asit_asso.extract.domain.Process;
 import ch.asit_asso.extract.domain.Task;
 import ch.asit_asso.extract.persistence.TasksRepository;
@@ -275,7 +276,7 @@ public class TaskModel extends PluginItemModel {
      */
     public final Task createDomainTask(final Process process) {
         final Task domainTask = new Task();
-        domainTask.setId(this.getId());
+        domainTask.setId(this.isNew() ? null : this.getId());
         domainTask.setCode(this.getPluginCode());
         domainTask.setLabel(this.getPluginLabel());
 
@@ -284,6 +285,21 @@ public class TaskModel extends PluginItemModel {
         }
 
         return this.updateDomainTask(domainTask);
+    }
+
+
+
+    /**
+     * Obtains whether this task has yet to be created in the data source.
+     *
+     * A task that has just been added through the interface carries the identifier that the form gave it to tell
+     * it apart from the other blocks of the page. That identifier is not the one of a row of the data source, and
+     * it must never be used to fetch one.
+     *
+     * @return <code>true</code> if this task does not exist in the data source yet
+     */
+    public final boolean isNew() {
+        return TaskModel.TAG_ADDED.equals(this.getTag()) || this.getId() == null;
     }
 
 
@@ -312,14 +328,37 @@ public class TaskModel extends PluginItemModel {
 
 
 
+    /**
+     * Reports the current values of this task in the data source.
+     *
+     * The task to update is looked for among the tasks of the process being saved, and nowhere else. The
+     * identifier that the form carries is either the temporary one of a task that has just been added, or the one
+     * of a task of another process when the form has been tampered with or restored by the browser. Fetching it
+     * from the whole table would overwrite the position and the parameters of a task that this process has no
+     * business touching, and leave it attached to its own process (issue #425). An identifier that is none of
+     * this process's tasks is therefore refused rather than turned into a new task, so that a caller that skipped
+     * {@link ProcessModel#getForeignTaskIds(Process)} cannot write anything unexpected either.
+     *
+     * @param taskRepository the link between the task data objects and the data source
+     * @param domainProcess  the data object of the process that this task is part of
+     * @return the saved task data object
+     */
     public final Task saveInDataSource(final TasksRepository taskRepository,
             final Process domainProcess) {
-        Task domainTask = taskRepository.findById(this.getId()).orElse(null);
+        Task domainTask;
 
-        if (domainTask == null) {
+        if (this.isNew()) {
             domainTask = this.createDomainTask(domainProcess);
 
         } else {
+            domainTask = this.findInProcess(domainProcess);
+
+            if (domainTask == null) {
+                throw new IllegalArgumentException(String.format(
+                        "The task with identifier %s is not a task of the process with identifier %s.", this.getId(),
+                        (domainProcess != null) ? domainProcess.getId() : null));
+            }
+
             this.updateDomainTask(domainTask);
         }
 
@@ -330,6 +369,30 @@ public class TaskModel extends PluginItemModel {
         }
 
         return domainTask;
+    }
+
+
+
+    /**
+     * Obtains the data object of this task among those of the process that it is part of.
+     *
+     * @param domainProcess the data object of the process being saved
+     * @return the task data object, or <code>null</code> if it is not one of that process's tasks
+     */
+    private Task findInProcess(final Process domainProcess) {
+
+        if (domainProcess == null || domainProcess.getTasksCollection() == null) {
+            return null;
+        }
+
+        for (Task domainTask : domainProcess.getTasksCollection()) {
+
+            if (Objects.equals(domainTask.getId(), this.getId())) {
+                return domainTask;
+            }
+        }
+
+        return null;
     }
 
 

--- a/extract/src/main/resources/messages_de.properties
+++ b/extract/src/main/resources/messages_de.properties
@@ -236,6 +236,7 @@ processDetails.panels.availableTasks.description=Ziehen Sie eine Aufgabe nach li
 processDetails.panels.tasks.emptyPlaceholder=Aufgaben hierher ziehen und ablegen
 processDetails.panels.tasks.helplink=Hilfe
 processDetails.errors.task.notFound=Die angegebene Aufgabe existiert nicht
+processDetails.errors.task.foreign=Die gesendeten Daten verweisen auf eine Aufgabe, die nicht zu dieser Verarbeitung gehört. Es wurde nichts gespeichert. Laden Sie die Seite neu und versuchen Sie es erneut.
 processDetails.task.help.title=Beschreibung der Aufgabe
 
 #Requests list page

--- a/extract/src/main/resources/messages_en.properties
+++ b/extract/src/main/resources/messages_en.properties
@@ -234,6 +234,7 @@ processDetails.panels.availableTasks.description=Drag a task to the left to add 
 processDetails.panels.tasks.emptyPlaceholder=Drag and drop tasks here
 processDetails.panels.tasks.helplink=help
 processDetails.errors.task.notFound=The specified task does not exist
+processDetails.errors.task.foreign=The submitted data refers to a task that does not belong to this process. Nothing has been saved. Reload the page and try again.
 processDetails.task.help.title=Task description
 
 #Requests list page

--- a/extract/src/main/resources/messages_fr.properties
+++ b/extract/src/main/resources/messages_fr.properties
@@ -234,6 +234,7 @@ processDetails.panels.availableTasks.description=Glissez une t\u00e2che vers la 
 processDetails.panels.tasks.emptyPlaceholder=Glisser-d\u00e9poser des t\u00e2ches ici
 processDetails.panels.tasks.helplink=aide
 processDetails.errors.task.notFound=La t\u00e2che indiqu\u00e9e n'existe pas
+processDetails.errors.task.foreign=Les donn\u00e9es envoy\u00e9es font r\u00e9f\u00e9rence \u00e0 une t\u00e2che qui n'appartient pas \u00e0 ce traitement. Rien n'a \u00e9t\u00e9 enregistr\u00e9. Rechargez la page et recommencez.
 processDetails.task.help.title=Description de la t\u00e2che
 
 #Requests list page

--- a/extract/src/test/java/ch/asit_asso/extract/integration/processes/ProcessTaskOwnershipIntegrationTest.java
+++ b/extract/src/test/java/ch/asit_asso/extract/integration/processes/ProcessTaskOwnershipIntegrationTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2026 asit-asso
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.asit_asso.extract.integration.processes;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import ch.asit_asso.extract.domain.Process;
+import ch.asit_asso.extract.domain.Task;
+import ch.asit_asso.extract.integration.DatabaseTestHelper;
+import ch.asit_asso.extract.integration.WithMockApplicationUser;
+import ch.asit_asso.extract.persistence.ProcessesRepository;
+import ch.asit_asso.extract.persistence.TasksRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for the tasks written when a process is saved (issue #425).
+ *
+ * Saving a process used to write into whichever task carried the identifier that the form sent, wherever that task
+ * lived. A task added through the interface gets a temporary identifier computed from the tasks of the form, so it
+ * regularly carries the real identifier of a task of another process: that task was then given the position and
+ * the parameters of the added one, and stayed attached to its own process, which no interface can undo.
+ *
+ * These tests run the real controller against a real PostgreSQL, and assert on the other process, which must come
+ * out of the save exactly as it went in.
+ *
+ * @author Bruno Alves
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Tag("integration")
+@DisplayName("Process Task Ownership Integration Tests (issue #425)")
+class ProcessTaskOwnershipIntegrationTest {
+
+    /**
+     * Prefixes the seeded values, so that they cannot collide with the test data set.
+     */
+    private static final String MARKER = "ZZ425";
+
+    /**
+     * The path of the script that the untouched task must still hold.
+     */
+    private static final String OTHER_SCRIPT = "/opt/scripts/zz425.py";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ProcessesRepository processesRepository;
+
+    @Autowired
+    private TasksRepository tasksRepository;
+
+    @Autowired
+    private DatabaseTestHelper dbHelper;
+
+    private int operatorId;
+
+
+
+    @BeforeEach
+    public void setUp() {
+        this.operatorId = this.dbHelper.createTestOperator(ProcessTaskOwnershipIntegrationTest.MARKER + "_operator",
+                                                           ProcessTaskOwnershipIntegrationTest.MARKER + " Operator",
+                                                           ProcessTaskOwnershipIntegrationTest.MARKER + "@test.ch",
+                                                           true);
+    }
+
+
+
+    @Nested
+    @DisplayName("1. Adding a task")
+    class AddedTaskTests {
+
+        @Test
+        @DisplayName("1.1 - A task added with the identifier of another process's task leaves that task alone")
+        @WithMockApplicationUser(username = "admin", userId = 2, role = "ADMIN")
+        @Transactional
+        void anAddedTaskDoesNotOverwriteTheTaskOfAnotherProcess() throws Exception {
+            final Task otherTask = ProcessTaskOwnershipIntegrationTest.this.pythonTask();
+            final Process editedProcess = ProcessTaskOwnershipIntegrationTest.this.process("edited");
+
+            ProcessTaskOwnershipIntegrationTest.this.mockMvc.perform(
+                    ProcessTaskOwnershipIntegrationTest.this.saveWithArchiveTask(editedProcess, otherTask.getId(),
+                                                                                 true))
+                                                            .andExpect(status().is3xxRedirection());
+
+            final Task reloadedOtherTask
+                    = ProcessTaskOwnershipIntegrationTest.this.tasksRepository.findById(otherTask.getId())
+                                                                             .orElseThrow();
+            assertEquals("python", reloadedOtherTask.getCode(), "The task of the other process changed plugin.");
+            assertEquals(1, reloadedOtherTask.getPosition(), "The task of the other process changed position.");
+            assertEquals(ProcessTaskOwnershipIntegrationTest.OTHER_SCRIPT,
+                         reloadedOtherTask.getParametersValues().get("pythonScript"),
+                         "The task of the other process lost its parameters.");
+
+            final Task[] savedTasks
+                    = ProcessTaskOwnershipIntegrationTest.this.tasksRepository
+                            .findByProcessOrderByPosition(editedProcess);
+            assertEquals(1, savedTasks.length, "The edited process must have got its new task.");
+            assertNotEquals(otherTask.getId(), savedTasks[0].getId(),
+                            "The new task must have an identifier of its own.");
+            assertEquals("ARCHIVE", savedTasks[0].getCode(), "The new task must use the plugin that was added.");
+        }
+    }
+
+
+
+    @Nested
+    @DisplayName("2. Submitting a task that belongs to another process")
+    class ForeignTaskTests {
+
+        @Test
+        @DisplayName("2.1 - The save is refused and nothing is written")
+        @WithMockApplicationUser(username = "admin", userId = 2, role = "ADMIN")
+        @Transactional
+        void aForeignTaskIdentifierIsRefused() throws Exception {
+            final Task otherTask = ProcessTaskOwnershipIntegrationTest.this.pythonTask();
+            final Process editedProcess = ProcessTaskOwnershipIntegrationTest.this.process("edited");
+
+            ProcessTaskOwnershipIntegrationTest.this.mockMvc.perform(
+                    ProcessTaskOwnershipIntegrationTest.this.saveWithArchiveTask(editedProcess, otherTask.getId(),
+                                                                                 false))
+                                                            .andExpect(status().isOk());
+
+            final Task reloadedOtherTask
+                    = ProcessTaskOwnershipIntegrationTest.this.tasksRepository.findById(otherTask.getId())
+                                                                             .orElseThrow();
+            assertEquals("python", reloadedOtherTask.getCode(), "The task of the other process changed plugin.");
+            assertEquals(ProcessTaskOwnershipIntegrationTest.OTHER_SCRIPT,
+                         reloadedOtherTask.getParametersValues().get("pythonScript"),
+                         "The task of the other process lost its parameters.");
+            assertEquals(0,
+                         ProcessTaskOwnershipIntegrationTest.this.tasksRepository
+                                 .findByProcessOrderByPosition(editedProcess).length,
+                         "Nothing must have been written for the edited process.");
+        }
+    }
+
+
+
+
+    /**
+     * Creates a process that holds no task.
+     *
+     * The collections are set even though they are empty, because a process that has just been persisted carries
+     * null ones until it is read again, whereas the application always works on processes that it has loaded, and
+     * thus on empty collections.
+     *
+     * @param nameSuffix what tells this process apart from the other ones of the test
+     * @return the process data object
+     */
+    private Process process(final String nameSuffix) {
+        final Process domainProcess = new Process();
+        domainProcess.setName(String.format("%s %s", ProcessTaskOwnershipIntegrationTest.MARKER, nameSuffix));
+        domainProcess.setTasksCollection(new ArrayList<>());
+        domainProcess.setUsersCollection(new ArrayList<>());
+        domainProcess.setUserGroupsCollection(new ArrayList<>());
+
+        return this.processesRepository.save(domainProcess);
+    }
+
+
+
+    /**
+     * Creates a process of its own holding a task that uses a plugin with mandatory parameters.
+     *
+     * @return the task data object
+     */
+    private Task pythonTask() {
+        final Process otherProcess = this.process("other");
+        final Task domainTask = new Task();
+        domainTask.setCode("python");
+        domainTask.setLabel("Extraction Python");
+        domainTask.setPosition(1);
+        domainTask.setProcess(otherProcess);
+        final HashMap<String, String> values = new HashMap<>();
+        values.put("pythonScript", ProcessTaskOwnershipIntegrationTest.OTHER_SCRIPT);
+        values.put("pythonInterpreter", "/usr/bin/python3");
+        domainTask.setParametersValues(values);
+
+        return this.tasksRepository.save(domainTask);
+    }
+
+
+
+    /**
+     * Builds the submission of a process holding a single archive task that carries a given identifier.
+     *
+     * @param editedProcess the process being saved
+     * @param taskId        the identifier that the task block carries
+     * @param added         <code>true</code> to tag the task as one that the interface has just added
+     * @return the request to perform
+     */
+    private MockHttpServletRequestBuilder saveWithArchiveTask(final Process editedProcess, final int taskId,
+            final boolean added) {
+        return post("/processes/{id}", editedProcess.getId()).with(csrf())
+                .param("id", String.valueOf(editedProcess.getId()))
+                .param("name", editedProcess.getName())
+                .param("readOnly", "false")
+                .param("htmlScrollY", "0")
+                .param("usersIds", String.valueOf(this.operatorId))
+                .param("userGroupsIds", "")
+                .param("tasks[0].id", String.valueOf(taskId))
+                .param("tasks[0].pluginCode", "ARCHIVE")
+                .param("tasks[0].pluginLabel", "Archivage fichiers")
+                .param("tasks[0].pluginPictoClass", "fa-folder")
+                .param("tasks[0].tag", added ? "ADDED" : "")
+                .param("tasks[0].position", "1")
+                .param("tasks[0].parameters[0].name", "path")
+                .param("tasks[0].parameters[0].type", "text")
+                .param("tasks[0].parameters[0].label", "Chemin")
+                .param("tasks[0].parameters[0].required", "true")
+                .param("tasks[0].parameters[0].maxLength", "255")
+                .param("tasks[0].parameters[0].value", "/tmp/" + ProcessTaskOwnershipIntegrationTest.MARKER);
+    }
+}

--- a/extract/src/test/java/ch/asit_asso/extract/integration/processes/ProcessTaskOwnershipIntegrationTest.java
+++ b/extract/src/test/java/ch/asit_asso/extract/integration/processes/ProcessTaskOwnershipIntegrationTest.java
@@ -166,6 +166,31 @@ class ProcessTaskOwnershipIntegrationTest {
                                  .findByProcessOrderByPosition(editedProcess).length,
                          "Nothing must have been written for the edited process.");
         }
+
+
+
+        @Test
+        @DisplayName("2.2 - Creating a process with a task that claims an identifier writes nothing at all")
+        @WithMockApplicationUser(username = "admin", userId = 2, role = "ADMIN")
+        @Transactional
+        void aForeignTaskIdentifierIsRefusedOnCreation() throws Exception {
+            final Task otherTask = ProcessTaskOwnershipIntegrationTest.this.pythonTask();
+            final long processesBefore
+                    = ProcessTaskOwnershipIntegrationTest.this.processesRepository.count();
+
+            ProcessTaskOwnershipIntegrationTest.this.mockMvc.perform(
+                    ProcessTaskOwnershipIntegrationTest.this.createWithArchiveTask(otherTask.getId()))
+                                                            .andExpect(status().isOk());
+
+            assertEquals(processesBefore,
+                         ProcessTaskOwnershipIntegrationTest.this.processesRepository.count(),
+                         "No process must have been created.");
+            final Task reloadedOtherTask
+                    = ProcessTaskOwnershipIntegrationTest.this.tasksRepository.findById(otherTask.getId())
+                                                                             .orElseThrow();
+            assertEquals("python", reloadedOtherTask.getCode(), "The task of the other process changed plugin.");
+            assertEquals(1, reloadedOtherTask.getPosition(), "The task of the other process changed position.");
+        }
     }
 
 
@@ -237,6 +262,36 @@ class ProcessTaskOwnershipIntegrationTest {
                 .param("tasks[0].pluginLabel", "Archivage fichiers")
                 .param("tasks[0].pluginPictoClass", "fa-folder")
                 .param("tasks[0].tag", added ? "ADDED" : "")
+                .param("tasks[0].position", "1")
+                .param("tasks[0].parameters[0].name", "path")
+                .param("tasks[0].parameters[0].type", "text")
+                .param("tasks[0].parameters[0].label", "Chemin")
+                .param("tasks[0].parameters[0].required", "true")
+                .param("tasks[0].parameters[0].maxLength", "255")
+                .param("tasks[0].parameters[0].value", "/tmp/" + ProcessTaskOwnershipIntegrationTest.MARKER);
+    }
+
+
+
+    /**
+     * Builds the creation of a process holding a single archive task that claims a given identifier.
+     *
+     * @param taskId the identifier that the task block carries
+     * @return the request to perform
+     */
+    private MockHttpServletRequestBuilder createWithArchiveTask(final int taskId) {
+        return post("/processes/add").with(csrf())
+                .param("id", "0")
+                .param("name", ProcessTaskOwnershipIntegrationTest.MARKER + " created")
+                .param("readOnly", "false")
+                .param("htmlScrollY", "0")
+                .param("usersIds", String.valueOf(this.operatorId))
+                .param("userGroupsIds", "")
+                .param("tasks[0].id", String.valueOf(taskId))
+                .param("tasks[0].pluginCode", "ARCHIVE")
+                .param("tasks[0].pluginLabel", "Archivage fichiers")
+                .param("tasks[0].pluginPictoClass", "fa-folder")
+                .param("tasks[0].tag", "")
                 .param("tasks[0].position", "1")
                 .param("tasks[0].parameters[0].name", "path")
                 .param("tasks[0].parameters[0].type", "text")

--- a/extract/src/test/java/ch/asit_asso/extract/unit/web/model/TaskOwnershipTest.java
+++ b/extract/src/test/java/ch/asit_asso/extract/unit/web/model/TaskOwnershipTest.java
@@ -207,6 +207,31 @@ class TaskOwnershipTest {
 
             assertArrayEquals(new Integer[]{}, processModel.getForeignTaskIds(editedProcess));
         }
+
+
+
+        @Test
+        @DisplayName("2.4 - A task claiming an identifier is reported when the process is being created")
+        void aTaskWithAnIdentifierIsReportedOnCreation() {
+            final ProcessModel processModel = TaskOwnershipTest.this.processModel(0,
+                                                                                  TaskOwnershipTest.FOREIGN_TASK_ID);
+
+            assertArrayEquals(new Integer[]{TaskOwnershipTest.FOREIGN_TASK_ID}, processModel.getForeignTaskIds());
+        }
+
+
+
+        @Test
+        @DisplayName("2.5 - The tasks of a process being created are accepted when they are all new")
+        void addedTasksAreAcceptedOnCreation() {
+            final ProcessModel processModel = TaskOwnershipTest.this.processModel(0);
+            final TaskModel addedTask = TaskOwnershipTest.this.taskModel(ITaskProcessorStub.ARCHIVE);
+            addedTask.setTag(TaskModel.TAG_ADDED);
+            addedTask.setId(TaskOwnershipTest.FOREIGN_TASK_ID);
+            processModel.setTasks(new TaskModel[]{addedTask});
+
+            assertArrayEquals(new Integer[]{}, processModel.getForeignTaskIds());
+        }
     }
 
 

--- a/extract/src/test/java/ch/asit_asso/extract/unit/web/model/TaskOwnershipTest.java
+++ b/extract/src/test/java/ch/asit_asso/extract/unit/web/model/TaskOwnershipTest.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright (C) 2026 asit-asso
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.asit_asso.extract.unit.web.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import ch.asit_asso.extract.domain.Process;
+import ch.asit_asso.extract.domain.Task;
+import ch.asit_asso.extract.persistence.TasksRepository;
+import ch.asit_asso.extract.plugins.common.ITaskProcessor;
+import ch.asit_asso.extract.web.model.ProcessModel;
+import ch.asit_asso.extract.web.model.TaskModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that saving a process cannot write into a task of another process (issue #425).
+ *
+ * The identifier that the form carries for a task is not trustworthy: a task added through the interface gets a
+ * temporary identifier computed from the tasks of the form, which is very likely to be the real identifier of a
+ * task of another process, and the browser can restore a value of its own into a field of the same name. Only the
+ * tasks that the edited process holds may be written to.
+ *
+ * @author Bruno Alves
+ */
+@DisplayName("Task Ownership Tests (issue #425)")
+class TaskOwnershipTest {
+
+    /**
+     * The parameters of a plugin whose settings are mandatory, as the Python extraction plugin's are.
+     */
+    private static final String PYTHON_PARAMETERS
+            = "[{\"code\": \"pythonScript\", \"label\": \"Script\", \"type\": \"text\", \"req\": true,"
+            + " \"maxlength\": 500}]";
+
+    /**
+     * The parameters of another plugin, which have nothing in common with the ones above.
+     */
+    private static final String ARCHIVE_PARAMETERS
+            = "[{\"code\": \"path\", \"label\": \"Chemin\", \"type\": \"text\", \"req\": true, \"maxlength\": 255}]";
+
+    /**
+     * The identifier of the task that belongs to another process.
+     */
+    private static final int FOREIGN_TASK_ID = 1473;
+
+    private TasksRepository tasksRepository;
+
+
+
+    @BeforeEach
+    public void setUp() {
+        this.tasksRepository = mock(TasksRepository.class);
+        when(this.tasksRepository.save(any(Task.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+
+
+    @Nested
+    @DisplayName("1. Saving a task")
+    class SavingTests {
+
+        @Test
+        @DisplayName("1.1 - A task that has just been added does not write into the task that shares its identifier")
+        void anAddedTaskLeavesTheTaskWithTheSameIdentifierAlone() {
+            final Task foreignTask = TaskOwnershipTest.this.pythonTaskInTheDataSource(TaskOwnershipTest.FOREIGN_TASK_ID);
+            final Process editedProcess = TaskOwnershipTest.this.process(1426);
+            final TaskModel addedTask = TaskOwnershipTest.this.taskModel(ITaskProcessorStub.ARCHIVE);
+            addedTask.setTag(TaskModel.TAG_ADDED);
+            addedTask.setId(TaskOwnershipTest.FOREIGN_TASK_ID);
+            addedTask.setPosition(6);
+
+            addedTask.saveInDataSource(TaskOwnershipTest.this.tasksRepository, editedProcess);
+
+            final ArgumentCaptor<Task> savedTask = ArgumentCaptor.forClass(Task.class);
+            verify(TaskOwnershipTest.this.tasksRepository).save(savedTask.capture());
+            assertNotSame(foreignTask, savedTask.getValue(), "The added task must not be the task of the other"
+                    + " process.");
+            assertNull(savedTask.getValue().getId(), "A task that does not exist yet must be saved without an"
+                    + " identifier, so that the data source assigns a real one.");
+            assertSame(editedProcess, savedTask.getValue().getProcess(), "The added task must belong to the edited"
+                    + " process.");
+            assertEquals("python", foreignTask.getCode(), "The task of the other process must be untouched.");
+            assertEquals(2, foreignTask.getPosition(), "The position of the task of the other process must be"
+                    + " untouched.");
+            assertEquals("/opt/scripts/other.py", foreignTask.getParametersValues().get("pythonScript"),
+                         "The parameters of the task of the other process must be untouched.");
+        }
+
+
+
+        @Test
+        @DisplayName("1.2 - A task identifier that is none of the process's tasks is refused without writing")
+        void aForeignTaskIdentifierIsRefused() {
+            final Task foreignTask
+                    = TaskOwnershipTest.this.pythonTaskInTheDataSource(TaskOwnershipTest.FOREIGN_TASK_ID);
+            final Process editedProcess = TaskOwnershipTest.this.process(1426);
+            final TaskModel foreignTaskModel = TaskOwnershipTest.this.taskModel(ITaskProcessorStub.ARCHIVE);
+            foreignTaskModel.setId(TaskOwnershipTest.FOREIGN_TASK_ID);
+            foreignTaskModel.setPosition(6);
+
+            assertThrows(IllegalArgumentException.class,
+                         () -> foreignTaskModel.saveInDataSource(TaskOwnershipTest.this.tasksRepository,
+                                                                 editedProcess));
+            verify(TaskOwnershipTest.this.tasksRepository, never()).save(any(Task.class));
+            assertEquals(2, foreignTask.getPosition(), "The task of the other process must be untouched.");
+            assertEquals("/opt/scripts/other.py", foreignTask.getParametersValues().get("pythonScript"),
+                         "The parameters of the task of the other process must be untouched.");
+        }
+
+
+
+        @Test
+        @DisplayName("1.3 - A task of the process is still updated in place")
+        void aTaskOfTheProcessIsUpdatedInPlace() {
+            final Process editedProcess = TaskOwnershipTest.this.process(1426);
+            final Task ownTask = TaskOwnershipTest.this.archiveTask(12, editedProcess);
+            final TaskModel taskModel = TaskOwnershipTest.this.taskModel(ITaskProcessorStub.ARCHIVE);
+            taskModel.setId(12);
+            taskModel.setPosition(3);
+            taskModel.getParameterByName("path").setValue("/tmp/nouveau");
+
+            taskModel.saveInDataSource(TaskOwnershipTest.this.tasksRepository, editedProcess);
+
+            final ArgumentCaptor<Task> savedTask = ArgumentCaptor.forClass(Task.class);
+            verify(TaskOwnershipTest.this.tasksRepository).save(savedTask.capture());
+            assertSame(ownTask, savedTask.getValue(), "The task of the process must be the one that is saved.");
+            assertEquals(3, ownTask.getPosition(), "The position must have been updated.");
+            assertEquals("/tmp/nouveau", ownTask.getParametersValues().get("path"),
+                         "The parameter must have been updated.");
+        }
+    }
+
+
+
+    @Nested
+    @DisplayName("2. Checking the submitted tasks")
+    class ForeignTaskIdsTests {
+
+        @Test
+        @DisplayName("2.1 - A submitted task that belongs to another process is reported")
+        void aForeignTaskIsReported() {
+            final Process editedProcess = TaskOwnershipTest.this.process(1426);
+            TaskOwnershipTest.this.archiveTask(12, editedProcess);
+            final ProcessModel processModel = TaskOwnershipTest.this.processModel(1426, 12,
+                                                                                  TaskOwnershipTest.FOREIGN_TASK_ID);
+
+            assertArrayEquals(new Integer[]{TaskOwnershipTest.FOREIGN_TASK_ID},
+                              processModel.getForeignTaskIds(editedProcess));
+        }
+
+
+
+        @Test
+        @DisplayName("2.2 - Tasks that all belong to the process are accepted")
+        void ownTasksAreAccepted() {
+            final Process editedProcess = TaskOwnershipTest.this.process(1426);
+            TaskOwnershipTest.this.archiveTask(12, editedProcess);
+            TaskOwnershipTest.this.archiveTask(13, editedProcess);
+            final ProcessModel processModel = TaskOwnershipTest.this.processModel(1426, 12, 13);
+
+            assertArrayEquals(new Integer[]{}, processModel.getForeignTaskIds(editedProcess));
+        }
+
+
+
+        @Test
+        @DisplayName("2.3 - The temporary identifier of an added task is not reported")
+        void anAddedTaskIsNotReported() {
+            final Process editedProcess = TaskOwnershipTest.this.process(1426);
+            final ProcessModel processModel = TaskOwnershipTest.this.processModel(1426);
+            final TaskModel addedTask = TaskOwnershipTest.this.taskModel(ITaskProcessorStub.ARCHIVE);
+            addedTask.setTag(TaskModel.TAG_ADDED);
+            addedTask.setId(TaskOwnershipTest.FOREIGN_TASK_ID);
+            processModel.setTasks(new TaskModel[]{addedTask});
+
+            assertArrayEquals(new Integer[]{}, processModel.getForeignTaskIds(editedProcess));
+        }
+    }
+
+
+
+    @Nested
+    @DisplayName("3. Reading a task whose stored parameters do not fit its plugin")
+    class CorruptedParametersTests {
+
+        @Test
+        @DisplayName("3.1 - A task that lost its mandatory parameters can still be read")
+        void aTaskWithTheParametersOfAnotherPluginIsReadable() {
+            final Task corruptedTask = new Task(TaskOwnershipTest.FOREIGN_TASK_ID);
+            corruptedTask.setCode("python");
+            corruptedTask.setPosition(6);
+            final HashMap<String, String> archiveValues = new HashMap<>();
+            archiveValues.put("path", "/tmp/archive");
+            corruptedTask.setParametersValues(archiveValues);
+
+            final TaskModel taskModel = new TaskModel(corruptedTask, ITaskProcessorStub.PYTHON.plugin());
+
+            assertNull(taskModel.getParameterByName("pythonScript").getValue(),
+                       "The parameter that the data source no longer holds must be left empty.");
+            assertEquals(TaskOwnershipTest.FOREIGN_TASK_ID, taskModel.getId(),
+                         "The rest of the task must have been read.");
+        }
+
+
+
+        @Test
+        @DisplayName("3.2 - A task without any stored parameter can still be read")
+        void aTaskWithoutStoredParametersIsReadable() {
+            final Task emptyTask = new Task(12);
+            emptyTask.setCode("python");
+            emptyTask.setPosition(1);
+
+            final TaskModel taskModel = new TaskModel(emptyTask, ITaskProcessorStub.PYTHON.plugin());
+
+            assertNull(taskModel.getParameterByName("pythonScript").getValue(),
+                       "The mandatory parameter must be left empty.");
+        }
+    }
+
+
+
+    /**
+     * Makes a process data object that holds no task yet.
+     *
+     * @param processId the identifier of the process
+     * @return the process data object
+     */
+    private Process process(final int processId) {
+        final Process domainProcess = new Process(processId);
+        domainProcess.setTasksCollection(new ArrayList<>());
+
+        return domainProcess;
+    }
+
+
+
+    /**
+     * Makes a task of the Python plugin that belongs to a process of its own, and hands it out to whoever fetches
+     * it by its identifier alone.
+     *
+     * That global lookup is what used to make the bug: the task is not one of the edited process's, so the code
+     * under test must not reach for it, and these tests fail if it does.
+     *
+     * @param taskId the identifier of the task
+     * @return the task data object
+     */
+    private Task pythonTaskInTheDataSource(final int taskId) {
+        final Process otherProcess = this.process(1629);
+        final Task domainTask = new Task(taskId);
+        domainTask.setCode("python");
+        domainTask.setPosition(2);
+        domainTask.setProcess(otherProcess);
+        final HashMap<String, String> values = new HashMap<>();
+        values.put("pythonScript", "/opt/scripts/other.py");
+        domainTask.setParametersValues(values);
+        otherProcess.getTasksCollection().add(domainTask);
+        when(this.tasksRepository.findById(taskId)).thenReturn(Optional.of(domainTask));
+
+        return domainTask;
+    }
+
+
+
+    /**
+     * Makes a task of the archive plugin and adds it to a process.
+     *
+     * @param taskId        the identifier of the task
+     * @param domainProcess the process that the task is part of
+     * @return the task data object
+     */
+    private Task archiveTask(final int taskId, final Process domainProcess) {
+        final Task domainTask = new Task(taskId);
+        domainTask.setCode("ARCHIVE");
+        domainTask.setPosition(1);
+        domainTask.setProcess(domainProcess);
+        final HashMap<String, String> values = new HashMap<>();
+        values.put("path", "/tmp/ancien");
+        domainTask.setParametersValues(values);
+        domainProcess.getTasksCollection().add(domainTask);
+
+        return domainTask;
+    }
+
+
+
+    /**
+     * Makes the model of a task that uses a given plugin.
+     *
+     * @param plugin the plugin used by the task
+     * @return the task model
+     */
+    private TaskModel taskModel(final ITaskProcessorStub plugin) {
+        return new TaskModel(plugin.plugin());
+    }
+
+
+
+    /**
+     * Makes the model of a process that submits tasks with the given identifiers.
+     *
+     * @param processId the identifier of the process
+     * @param taskIds   the identifiers carried by the submitted tasks
+     * @return the process model
+     */
+    private ProcessModel processModel(final int processId, final int... taskIds) {
+        final ProcessModel processModel = new ProcessModel();
+        processModel.setId(processId);
+        final List<TaskModel> tasks = new ArrayList<>();
+
+        for (int taskId : taskIds) {
+            final TaskModel taskModel = this.taskModel(ITaskProcessorStub.ARCHIVE);
+            taskModel.setId(taskId);
+            tasks.add(taskModel);
+        }
+
+        processModel.setTasks(tasks.toArray(TaskModel[]::new));
+
+        return processModel;
+    }
+
+
+
+    /**
+     * The task plugins that these tests use.
+     */
+    private enum ITaskProcessorStub {
+
+        /**
+         * A plugin whose mandatory parameter is a script path.
+         */
+        PYTHON("python", TaskOwnershipTest.PYTHON_PARAMETERS),
+
+        /**
+         * A plugin whose mandatory parameter is a folder path.
+         */
+        ARCHIVE("ARCHIVE", TaskOwnershipTest.ARCHIVE_PARAMETERS);
+
+        private final String code;
+
+        private final String parameters;
+
+
+
+        ITaskProcessorStub(final String pluginCode, final String pluginParameters) {
+            this.code = pluginCode;
+            this.parameters = pluginParameters;
+        }
+
+
+
+        /**
+         * Makes an instance of this plugin.
+         *
+         * @return the plugin
+         */
+        public ITaskProcessor plugin() {
+            final ITaskProcessor plugin = mock(ITaskProcessor.class);
+            when(plugin.getCode()).thenReturn(this.code);
+            when(plugin.getLabel()).thenReturn(this.code);
+            when(plugin.getParams()).thenReturn(this.parameters);
+
+            return plugin;
+        }
+    }
+}

--- a/sql/create_test_data.sql
+++ b/sql/create_test_data.sql
@@ -189,8 +189,10 @@ ON CONFLICT (id_record) DO NOTHING;
 
 -- ==================== END TEST DATA FOR STANDBY REMINDERS ====================
 
--- Hibernate with hibernate.id.new_generator_mappings=true uses {entity_name}_seq pattern
--- We need to update both PostgreSQL SERIAL-style and Hibernate-style sequences
+-- Every entity of the application draws its identifier from the same hibernate_sequence, so the sequence has to
+-- be moved past the highest identifier of *all* of them. Leaving a table out sets it too low, and the next row
+-- written in that table fails on its primary key. Each max below is taken as "max + 1", which is the value the
+-- sequence must hand out next; nothing is added to it afterwards.
 DO $$
 DECLARE
     max_user_id INTEGER;
@@ -199,6 +201,12 @@ DECLARE
     max_task_id INTEGER;
     max_request_id INTEGER;
     max_history_id INTEGER;
+    max_usergroup_id INTEGER;
+    max_rule_id INTEGER;
+    max_remark_id INTEGER;
+    max_recovery_code_id INTEGER;
+    max_remember_me_id INTEGER;
+    next_shared_id INTEGER;
 BEGIN
     -- Get max IDs
     SELECT COALESCE(MAX(id_user), 0) + 1 INTO max_user_id FROM users;
@@ -207,6 +215,32 @@ BEGIN
     SELECT COALESCE(MAX(id_task), 0) + 1 INTO max_task_id FROM tasks;
     SELECT COALESCE(MAX(id_request), 0) + 1 INTO max_request_id FROM requests;
     SELECT COALESCE(MAX(id_record), 0) + 1 INTO max_history_id FROM request_history;
+
+    max_usergroup_id := 1;
+    max_rule_id := 1;
+    max_remark_id := 1;
+    max_recovery_code_id := 1;
+    max_remember_me_id := 1;
+
+    IF to_regclass('public.usergroups') IS NOT NULL THEN
+        SELECT COALESCE(MAX(id_usergroup), 0) + 1 INTO max_usergroup_id FROM usergroups;
+    END IF;
+    IF to_regclass('public.rules') IS NOT NULL THEN
+        SELECT COALESCE(MAX(id_rule), 0) + 1 INTO max_rule_id FROM rules;
+    END IF;
+    IF to_regclass('public.remarks') IS NOT NULL THEN
+        SELECT COALESCE(MAX(id_remark), 0) + 1 INTO max_remark_id FROM remarks;
+    END IF;
+    IF to_regclass('public.recovery_codes') IS NOT NULL THEN
+        SELECT COALESCE(MAX(id_code), 0) + 1 INTO max_recovery_code_id FROM recovery_codes;
+    END IF;
+    IF to_regclass('public.remember_me_tokens') IS NOT NULL THEN
+        SELECT COALESCE(MAX(id_code), 0) + 1 INTO max_remember_me_id FROM remember_me_tokens;
+    END IF;
+
+    next_shared_id := GREATEST(max_user_id, max_connector_id, max_process_id, max_task_id, max_request_id,
+                               max_history_id, max_usergroup_id, max_rule_id, max_remark_id, max_recovery_code_id,
+                               max_remember_me_id);
 
     -- Update PostgreSQL SERIAL-style sequences (if they exist)
     IF EXISTS (SELECT 1 FROM pg_sequences WHERE sequencename = 'users_id_user_seq') THEN
@@ -250,7 +284,7 @@ BEGIN
 
     -- Also check for hibernate_sequence (shared sequence in some configurations)
     IF EXISTS (SELECT 1 FROM pg_sequences WHERE sequencename = 'hibernate_sequence') THEN
-        PERFORM setval('hibernate_sequence', GREATEST(max_user_id, max_connector_id, max_process_id, max_task_id, max_request_id, max_history_id), false);
+        PERFORM setval('hibernate_sequence', next_shared_id, false);
     END IF;
 END
 $$;


### PR DESCRIPTION
Corrige #425.

## Ce qui se passait

Trois choses se sont alignées.

1. **Un id temporaire qui ressemble à un vrai.** Une tâche ajoutée via l'interface reçoit `ProcessModel.getTemporaryRuleId()`, soit le plus grand id du formulaire + 1. Pour le traitement 1426 ça donnait 1473, qui est l'id de la tâche Python du traitement 1629.
2. **Une lecture qui ignore le traitement.** `TaskModel.saveInDataSource()` allait chercher cet id avec `taskRepository.findById()`, sur toute la table, et tombait sur la tâche de l'autre traitement. `updateDomainTask()` y écrivait la position et les paramètres de la tâche ajoutée sans toucher à son `id_process` : la tâche restait dans le 1629, à la position du 1426, avec les paramètres du plugin d'archivage. Et la tâche voulue n'était jamais créée.
3. **Un affichage qui n'y survit pas.** Relire cette tâche construit son modèle depuis le plugin Python, dont `pythonInterpreter` et `pythonScript` sont obligatoires et ne sont plus stockés. `validateUpdatedValue()` lève, et comme la liste construit le modèle de tous les traitements, une seule tâche corrompue mettait la page entière en 500 pour tout le monde.

Tous les ids de l'application sortent du même `hibernate_sequence`, tables confondues : c'est pour ça que l'id inventé par le formulaire tombe si facilement sur une ligne existante, de n'importe quelle nature. La duplication densifie la plage concernée, la copie prenant les numéros qui suivent ceux de l'original — d'abord sa ligne traitement, puis ses tâches. Selon l'ordre d'écriture, la valeur inventée tombe sur une de ces tâches, sur la ligne traitement de la copie, ou sur rien. Seul le premier cas casse, et c'est celui qui a été signalé.

## Reproduction en local, avant correctif

Instance déployée, vraie base, navigateur réel. Quatre formes, aucune ne demande de trafiquer quoi que ce soit :

| Scénario | Résultat constaté en base |
| --- | --- |
| Créer un traitement et lui ajouter une tâche | vole la tâche 1 d'un autre traitement, le traitement créé reste sans tâche |
| Ajouter deux tâches en une session sur un traitement vide | écrase les tâches 1 et 2 d'un autre traitement, dont la Python → liste en 500 avec la stack de l'issue |
| Traitement existant à 2 tâches, avec un sibling dupliqué, on ajoute la 3ᵉ | la tâche VALIDATION du clone part en position 3 avec les paramètres de la Remarque fixe, la tâche voulue n'existe nulle part |
| Édition du clone lui-même | même chose, dans l'autre sens |

## Ce que fait la PR

| Fichier | Changement |
| --- | --- |
| `TaskModel.java` | Plus aucune requête sur toute la table. Une tâche taguée `ADDED` est toujours créée, et sauvée sans id pour que la séquence en attribue un vrai ; toute autre tâche est cherchée **uniquement** parmi les tâches du traitement sauvegardé, et un id qui n'en fait pas partie est refusé |
| `ProcessModel.java` | Nouveau `getForeignTaskIds()`, en deux formes : à la mise à jour on compare aux tâches du traitement, à la création aucune tâche ne peut revendiquer d'id. `getTemporaryRuleId()` renommé `getTemporaryTaskId()` et son commentaire corrigé : il parlait de règles et affirmait que la valeur était ignorée à la sauvegarde, ce qui était précisément le bug (remarque de @yblatti) |
| `ProcessesController.java` | La soumission est contrôlée **avant** la première écriture, à la mise à jour **et** à la création. La création sauve la ligne traitement avant ses tâches : sans ce contrôle, une soumission revendiquant un id laissait un traitement vide derrière elle et renvoyait un 500 |
| `PluginItemModel.java` | Une valeur stockée qui ne correspond plus au plugin laisse le paramètre vide avec un warning, au lieu de lever |
| `messages_fr/de/en` | Nouvelle clé `processDetails.errors.task.foreign` |

La duplication elle-même n'était pas en cause : `cloneProcess()` copie les tâches par `Task.createCopy()` et les écrit directement, sans passer par le modèle de formulaire.

## Vérifié au navigateur, après correctif

| Scénario | Résultat |
| --- | --- |
| Les quatre reproductions ci-dessus | tâche neuve créée avec un id de séquence, autre traitement intact, liste à 200 |
| Modifier un paramètre d'une tâche existante | mise à jour en place, pas de doublon |
| Réordonner par glisser-déposer | ok |
| Supprimer une tâche | ok, positions renumérotées |
| Deux onglets réels, sauvegarde depuis le formulaire périmé | passe, rien d'autre touché |
| Deux onglets réels, id du clone injecté dans un bloc existant | refusé, message, **rien** en base, aucune ERROR |
| Liste avec deux tâches corrompues en base | 200, paramètres affichés vides et corrigeables, au lieu du 500 |

## Repérer les installations déjà touchées

Une tâche corrompue ne fait tomber la page que si son plugin a des paramètres obligatoires, comme le Python. Avec un plugin qui n'en a pas, comme la validation opérateur, la tâche continue de tourner avec les réglages d'un autre et **rien ne le signale**. Une instance qui n'a jamais renvoyé de 500 peut donc être touchée : il faut regarder la table plutôt qu'attendre l'erreur. Signes : une tâche dont les paramètres stockés ne correspondent pas à ceux que déclare son plugin, ou un traitement avec deux tâches à la même position.

## Réparation à la main

Inchangée, comme décrit par @daniellappert. Un piège rencontré pendant la repro : donner à une ligne réparée un id que `hibernate_sequence` n'a pas encore atteint fait échouer l'insertion suivante sur la clé primaire, et pas forcément dans `tasks`. Réutiliser un id déjà consommé, ou avancer la séquence au-delà du plus grand id de **toutes** les tables qui y puisent.

## Correctif SQL sur les données de test

`sql/create_test_data.sql` calculait la valeur à donner à `hibernate_sequence` sur six tables seulement, en laissant de côté `usergroups`, `rules`, `remarks`, `recovery_codes` et `remember_me_tokens`. Sur une base où l'une d'elles porte le plus grand id, la séquence repartait en dessous et la première insertion dans cette table échouait sur sa clé primaire.

Les cinq tables entrent maintenant dans le calcul, chacune protégée par `to_regclass` pour que le script tourne encore sur un schéma qui n'en a pas. La valeur donnée à la séquence est inchangée sur le principe : le plus grand id plus un, pris sur l'ensemble.

Mesuré sur une base amorcée portant une remarque à l'id 500 : la séquence rend maintenant **501**, contre **12** avec l'ancien calcul.

## Hors périmètre, assumé

- **La contrainte d'unicité `(id_process, position)`** proposée dans l'issue ne peut pas être posée telle quelle : les tâches sont sauvées une par une, chacune dans sa transaction, aucune transaction ne couvre la boucle. Un réordonnancement fait donc cohabiter deux tâches sur la même position le temps d'une écriture — la repro locale le confirme — et une contrainte non différée le rejetterait. Il faudrait rendre la sauvegarde transactionnelle et poser un `DEFERRABLE INITIALLY DEFERRED`, chantier à part.
- **Les règles de connecteur.** Même mécanisme, et `updateConnectorRules()` respecte bien le tag `ADDED`, ce qui explique que le défaut ne s'y soit jamais vu. Mais il va toujours chercher une règle existante par son seul id, sur toute la table : une règle d'un autre connecteur pourrait être déplacée de la même façon. Non traité ici, aucun incident remonté. À trancher.

## Tests

`TaskOwnershipTest` (unitaire, 10 cas) et `ProcessTaskOwnershipIntegrationTest` (intégration, vrai PostgreSQL, 3 cas). Chacun a été exécuté contre le code non corrigé et **échoue** : le test remet la tâche étrangère à qui la cherche par son seul id, donc l'ancienne lecture le fait tomber ; et sans le contrôle à la création, le cas correspondant renvoie 500 au lieu de 200.

L'affichage tolérant n'a **pas** de test d'intégration, volontairement : les plugins de tâche ne sont pas résolus depuis le contexte des tests d'intégration, la tâche est écartée avant que ses paramètres soient lus, et un tel test passerait quoi qu'on fasse. J'en avais écrit un, une assertion sur la page rendue a montré qu'il ne prouvait rien, je l'ai retiré plutôt que de le garder comme fausse preuve. Ce chemin est couvert par deux tests unitaires et par la vérification sur instance déployée.

Suites complètes sous JDK 17 : **1407 unitaires**, **497 d'intégration**, 0 échec.

## Documentation

`docs/features/architecture.md`, nouvelle section « Saving the tasks of a process » : les deux règles à tenir pour tout code qui touche à ce formulaire, ce que font différemment les règles de connecteur, pourquoi les positions ne sont pas protégées par une contrainte, ce qu'implique la séquence partagée, et le piège de la réparation manuelle.
