### PR TITLE
fix #428: never write a rule that belongs to another connector

### DIFF
--- a/changelog/v2.4/ISSUE_428.md
+++ b/changelog/v2.4/ISSUE_428.md
@@ -70,39 +70,17 @@ due, and the unknown identifier answers 500. The fourth guards the tag path, whi
 
 ### Finding the installations that are already hit
 
-A connector that lost a rule reports nothing. Three read-only checks, run against a database where the corruption
-had been reproduced:
+A connector that lost a rule reports nothing, and neither does a task left with the settings of another plugin
+when that plugin has no mandatory parameter. An installation that has never answered a 500 can be affected all the
+same, so the data has to be looked at rather than waited for. Three traces to look for:
 
-```sql
--- 1. tasks sharing a position in the same process (issue #425 and this one leave that trace)
-SELECT id_process, position, count(*) AS nb,
-       string_agg(id_task::text || ':' || task_code, ', ') AS tasks
-FROM tasks GROUP BY id_process, position HAVING count(*) > 1 ORDER BY id_process, position;
+- two tasks sharing a position in the same process;
+- a task whose stored parameters are the ones another plugin expects;
+- a connector left without any rule.
 
--- 2. tasks holding the parameters of another plugin
-WITH keys AS (
-    SELECT t.id_task, t.task_code, t.id_process,
-           COALESCE((SELECT string_agg(k, ',' ORDER BY k)
-                     FROM jsonb_object_keys(t.task_params::jsonb) AS k), '') AS key_set
-    FROM tasks t WHERE t.task_params IS NOT NULL AND t.task_params <> ''
-), sets_per_plugin AS (
-    SELECT task_code, key_set, count(*) AS nb FROM keys WHERE key_set <> '' GROUP BY task_code, key_set
-), usual AS (
-    SELECT DISTINCT ON (task_code) task_code, key_set FROM sets_per_plugin ORDER BY task_code, nb DESC, key_set
-)
-SELECT k.id_task, k.id_process, k.task_code AS plugin, k.key_set AS stored_parameters,
-       u.task_code AS plugin_those_parameters_belong_to
-FROM keys k JOIN usual u ON u.key_set = k.key_set AND u.task_code <> k.task_code ORDER BY k.id_task;
-
--- 3. connectors left without any rule
-SELECT c.id_connector, c.name FROM connectors c
-LEFT JOIN rules r ON r.id_connector = c.id_connector
-GROUP BY c.id_connector, c.name HAVING count(r.id_rule) = 0 ORDER BY c.id_connector;
-```
-
-The second one reads what the plugins of the installation usually store, so it cannot decide anything about a
-plugin used by a single task in the whole database, and a connector that legitimately has no rule shows up in the
-third. Both are leads to look at, not verdicts.
+Read-only queries for those three checks are posted on the issue itself rather than shipped here: they read what
+the plugins of a given installation usually store, so they are leads to look at and not verdicts, and they belong
+to the operators running the repair, not to this fix.
 
 ### Documentation / i18n impact
 

--- a/changelog/v2.4/ISSUE_428.md
+++ b/changelog/v2.4/ISSUE_428.md
@@ -1,0 +1,117 @@
+# ISSUE_428 - Saving a connector could move a rule of another connector
+
+## Status: COMPLIANT
+
+### Issue Description
+
+Twin of #425, on the connector side. Saving a connector wrote into whichever rule carried the identifier that the
+form sent, wherever that rule lived.
+
+### What the reproduction showed
+
+Worse than the issue described. One save destroys **two** rules:
+
+| Before | After |
+| --- | --- |
+| connector "Bouchon" holds rule 1, `orderlabel == "AAA"` | rule 1 now belongs to the edited connector, criteria overwritten |
+| edited connector holds its own rule 15 | rule 15 **deleted** |
+| | "Bouchon" left with no rule at all |
+
+The rule is not copied, it is **moved**: `RuleModel.updateDomainRule()` calls `setConnector(domainConnector)`. The
+connector it came from silently loses the rule that routed part of its requests. The rule of the edited connector
+that the block stood for is then deleted as a leftover, because it is no longer among the submitted identifiers.
+
+Two more defects were met on the way, both on the same page, both answering a 500 where a message was due:
+
+1. **A rule identifier that exists nowhere.** `updateConnectorRules()` threw
+   `UnsupportedOperationException("Impossible to move a rule that does not exist")`, after the rules already
+   handled by the loop had been written.
+2. **A rule without a process.** `RuleValidator` rejected the field `idProcess`, while the property is named
+   `processId`. Spring answered `NotReadablePropertyException`, so leaving the process of a rule empty — a plain
+   user mistake — took the page down instead of showing "Veuillez associer un traitement à la règle".
+
+### Why the interface did not show it more often
+
+Unlike the tasks of a process, `updateConnectorRules()` did honour the `ADDED` tag, so adding a rule through the
+interface has always created it, whatever identifier the form made up. What was left exposed is an **untagged**
+block carrying a foreign identifier: a stale form, a browser restoring a value into a field of the same name — the
+forms of two connectors are identical — or a forged request.
+
+### Implementation Completed
+
+| File | Change |
+| --- | --- |
+| `web/model/RuleModel.java` | New `isNew()`, which reads the tag and **only** the tag. An identifier is not enough to tell a new rule from an existing one, and must not be: an untagged rule whose identifier is missing, negative or unknown is refused rather than created, or the check below could be walked around by sending an invalid identifier. |
+| `web/model/ConnectorModel.java` | New `getForeignRuleIds()`, in two forms: against the rules the connector holds when it is updated, against nothing when it is created, since a connector being created holds no rule. The comment of `getTemporaryRuleId()` was fixed: it claimed the value it returns is ignored on save, which was exactly the bug. |
+| `web/controllers/ConnectorsController.java` | `updateConnectorRules()` looks for a rule among the rules of the connector being saved, never in the whole table. Both the update and the creation check the whole submission before anything is written. The creation no longer fetches rules by identifier at all. |
+| `web/validators/RuleValidator.java` | Rejects `processId`, the name the property actually has. |
+| `messages_fr/de/en.properties` | New key `connectorDetails.errors.rule.foreign`. |
+
+### Scope: rules submitted at creation
+
+A connector being created holds no rule, and the interface offers no way to add one before the first save: the
+rules panel only appears once the connector exists. A submission that carries rules at creation can therefore only
+come from a forged or stale request. Those claiming an identifier are refused; those tagged as added are ignored,
+which is what the previous code did too.
+
+### Tests
+
+`RuleOwnershipTest` (new, unit) covers the model: the tag alone makes a rule new, an untagged rule is not new even
+without a usable identifier, a foreign identifier is reported, own rules are accepted, the temporary identifier of
+an added rule is not reported, and every identifier is reported when the connector is being created.
+
+`ConnectorRuleOwnershipIntegrationTest` (new, integration) runs the real controller against PostgreSQL: a foreign
+identifier is refused and both connectors come out untouched, an identifier that exists nowhere is refused instead
+of failing, creating a connector with a rule claiming an identifier writes neither the connector nor the rule, and
+a rule added with the identifier of another connector's rule is created with an identifier of its own.
+
+Run against the unpatched code, three of those four integration cases fail: two save-through where a refusal was
+due, and the unknown identifier answers 500. The fourth guards the tag path, which was already correct.
+
+### Finding the installations that are already hit
+
+A connector that lost a rule reports nothing. Three read-only checks, run against a database where the corruption
+had been reproduced:
+
+```sql
+-- 1. tasks sharing a position in the same process (issue #425 and this one leave that trace)
+SELECT id_process, position, count(*) AS nb,
+       string_agg(id_task::text || ':' || task_code, ', ') AS tasks
+FROM tasks GROUP BY id_process, position HAVING count(*) > 1 ORDER BY id_process, position;
+
+-- 2. tasks holding the parameters of another plugin
+WITH keys AS (
+    SELECT t.id_task, t.task_code, t.id_process,
+           COALESCE((SELECT string_agg(k, ',' ORDER BY k)
+                     FROM jsonb_object_keys(t.task_params::jsonb) AS k), '') AS key_set
+    FROM tasks t WHERE t.task_params IS NOT NULL AND t.task_params <> ''
+), sets_per_plugin AS (
+    SELECT task_code, key_set, count(*) AS nb FROM keys WHERE key_set <> '' GROUP BY task_code, key_set
+), usual AS (
+    SELECT DISTINCT ON (task_code) task_code, key_set FROM sets_per_plugin ORDER BY task_code, nb DESC, key_set
+)
+SELECT k.id_task, k.id_process, k.task_code AS plugin, k.key_set AS stored_parameters,
+       u.task_code AS plugin_those_parameters_belong_to
+FROM keys k JOIN usual u ON u.key_set = k.key_set AND u.task_code <> k.task_code ORDER BY k.id_task;
+
+-- 3. connectors left without any rule
+SELECT c.id_connector, c.name FROM connectors c
+LEFT JOIN rules r ON r.id_connector = c.id_connector
+GROUP BY c.id_connector, c.name HAVING count(r.id_rule) = 0 ORDER BY c.id_connector;
+```
+
+The second one reads what the plugins of the installation usually store, so it cannot decide anything about a
+plugin used by a single task in the whole database, and a connector that legitimately has no rule shows up in the
+third. Both are leads to look at, not verdicts.
+
+### Documentation / i18n impact
+
+- i18n: one new key, `connectorDetails.errors.rule.foreign`, in French, German and English.
+- `docs/features/architecture.md`: the "Saving the tasks of a process" subsection said the second rule was not
+  enforced on the connector side. It now is, and the subsection says so, renamed to cover both.
+- Database: no migration.
+
+### Conclusion
+
+A connector can no longer write into a rule that is not its own, a submission that references one is refused
+before anything is saved, and the two ways this page used to answer a 500 now answer a message.

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -602,6 +602,35 @@ orderlabel == “92445” AND perimeter intersects POLYGON((6.82 46.39,6.92 46.3
 orderlabel == “92445” AND parameters.format == “PDF"
 ```
 
+#### Saving the rules
+
+The rules of a connector are edited as blocks of a single form, and the whole form is posted back on every action:
+adding a rule, deleting one and reordering them all go through a submission of the page. Each block carries the
+identifier of the rule it stands for, in a hidden ``rules[i].id`` field.
+
+That identifier is **not trustworthy**. A block that has just been added gets a temporary identifier from
+``ConnectorModel.getTemporaryRuleId()``, which is the highest identifier of the form plus one, and every entity of
+the application draws its identifiers from the same ``hibernate_sequence``: that made-up value lands on an
+existing row very easily. A browser restoring a form can also put a value of its own into a field of the same
+name, the forms of two connectors being identical.
+
+Two rules follow, and any new code touching this form must keep them:
+
+* what makes a rule new is its ``tag`` field, set to ``ADDED``, and nothing else. An identifier is deliberately
+  not enough: an untagged rule whose identifier is missing, negative or unknown is refused rather than created,
+  otherwise the check below could be walked around by sending an invalid identifier;
+* a rule that is not tagged is looked for **among the rules of the edited connector only**, never in the whole
+  table. An identifier that is none of them is refused: ``ConnectorsController`` checks the whole submission with
+  ``ConnectorModel.getForeignRuleIds()`` before writing anything, when a connector is updated and when one is
+  created, so that a rejected form leaves the data source untouched.
+
+Fetching a rule by its identifier alone did more damage than the same defect on the tasks side (issue #425):
+``RuleModel.updateDomainRule()`` sets the connector of the rule, so the rule was **moved** to the edited
+connector, and the rule of that connector which the block stood for was deleted as a leftover. The connector the
+rule came from lost it without any sign.
+
+The tasks of a process are edited through the same mechanism and follow the same two rules.
+
 ### Authentication
 
 There are two types of users:

--- a/extract/src/main/java/ch/asit_asso/extract/web/controllers/ConnectorsController.java
+++ b/extract/src/main/java/ch/asit_asso/extract/web/controllers/ConnectorsController.java
@@ -17,6 +17,7 @@
 package ch.asit_asso.extract.web.controllers;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.validation.Valid;
 
@@ -178,26 +179,17 @@ public class ConnectorsController extends BaseController {
             return this.prepareModelForDetailsView(model, true);
         }
 
-        final Connector domainConnector = connectorModel.createDomainConnector();
+        final Integer[] foreignRuleIds = connectorModel.getForeignRuleIds();
 
-        //save rules
-        int position = 1;
+        if (foreignRuleIds.length > 0) {
+            this.logger.error("Could not create the connector because the submitted rules {} claim to exist"
+                    + " already. Nothing has been saved.", Arrays.toString(foreignRuleIds));
+            this.addStatusMessage(model, "connectorDetails.errors.rule.foreign", Message.MessageType.ERROR);
 
-        for (RuleModel ruleModel : connectorModel.getRules()) {
-            Rule domainRule = this.rulesRepository.findById(ruleModel.getId()).orElse(null);
-            Process domainProcess = null;
-
-            if (ruleModel.getProcessId() >= 0) {
-                domainProcess = this.processesRepository.findById(ruleModel.getProcessId()).orElse(null);
-            }
-
-            if (domainRule != null) {
-                ruleModel.updateDomainRule(domainRule, domainConnector, domainProcess);
-                domainRule.setPosition(position);
-            }
-
-            position++;
+            return this.prepareModelForDetailsView(model, true);
         }
+
+        final Connector domainConnector = connectorModel.createDomainConnector();
         this.connectorsRepository.save(domainConnector);
 
         this.addStatusMessage(redirectAttributes, "connectorsList.connector.added", Message.MessageType.SUCCESS);
@@ -242,6 +234,16 @@ public class ConnectorsController extends BaseController {
                     Message.MessageType.ERROR);
 
             return ConnectorsController.REDIRECT_TO_LIST;
+        }
+
+        final Integer[] foreignRuleIds = connectorModel.getForeignRuleIds(domainConnector);
+
+        if (foreignRuleIds.length > 0) {
+            this.logger.error("Could not update the connector {} because the submitted rules {} are not its own."
+                    + " Nothing has been saved.", domainConnector.getId(), Arrays.toString(foreignRuleIds));
+            this.addStatusMessage(model, "connectorDetails.errors.rule.foreign", Message.MessageType.ERROR);
+
+            return this.prepareModelForDetailsView(model, false);
         }
 
         connectorModel.updateDomainConnector(domainConnector);
@@ -585,14 +587,18 @@ public class ConnectorsController extends BaseController {
                             .orElse(null);
             Rule domainRule;
 
-            if (RuleModel.TAG_ADDED.equals(ruleModel.getTag())) {
+            if (ruleModel.isNew()) {
                 domainRule = ruleModel.createDomainRule(domainConnector, domainProcess);
                 domainRule.setPosition(ruleModel.getPosition());
             } else {
-                domainRule = this.rulesRepository.findById(ruleModel.getId())
-                    .orElseThrow(() -> {
-                        return new UnsupportedOperationException("Impossible to move a rule that does not exist");
-                    });
+                domainRule = ConnectorsController.findInConnector(domainConnector, ruleModel.getId());
+
+                if (domainRule == null) {
+                    throw new IllegalArgumentException(String.format(
+                            "The rule with identifier %d is not a rule of the connector with identifier %s.",
+                            ruleModel.getId(), domainConnector.getId()));
+                }
+
                 rulesToDelete.remove(domainRule);
                 ruleModel.updateDomainRule(domainRule, domainConnector, domainProcess);
                 domainRule.setPosition(ruleModel.getPosition());
@@ -603,6 +609,36 @@ public class ConnectorsController extends BaseController {
 
         domainConnector.getRulesCollection().removeAll(rulesToDelete);
         this.rulesRepository.deleteAll(rulesToDelete);
+    }
+
+
+
+    /**
+     * Obtains the data object of a rule among those of the connector being saved.
+     *
+     * The identifier that the form carries is either the temporary one of a rule that has just been added, or the
+     * one of a rule of another connector when the form has been tampered with or restored by the browser. Fetching
+     * it from the whole table would move that rule to the edited connector, overwrite its criteria and its target
+     * process, and leave its own connector without it (issue #428).
+     *
+     * @param domainConnector the data object of the connector being saved
+     * @param ruleId          the identifier carried by the submitted rule
+     * @return the rule data object, or <code>null</code> if it is not one of that connector's rules
+     */
+    private static Rule findInConnector(final Connector domainConnector, final int ruleId) {
+
+        if (domainConnector.getRulesCollection() == null) {
+            return null;
+        }
+
+        for (Rule domainRule : domainConnector.getRulesCollection()) {
+
+            if (domainRule.getId() != null && domainRule.getId() == ruleId) {
+                return domainRule;
+            }
+        }
+
+        return null;
     }
 
 }

--- a/extract/src/main/java/ch/asit_asso/extract/web/model/ConnectorModel.java
+++ b/extract/src/main/java/ch/asit_asso/extract/web/model/ConnectorModel.java
@@ -574,11 +574,13 @@ public class ConnectorModel extends PluginItemModel {
 
 
     /**
-     * Provides a temporary identifier for a new rule. This only ensures that the new object has a unique
-     * identifier among the rules for this controller until it is saved. But this value should be ignored when this
-     * rule is persisted. The real identifier should be assigned by the regular means, e.g. database sequence.
+     * Provides a temporary identifier for a rule that has just been added.
      *
-     * @return a temporary identifier that is unique among the rules for this connector
+     * This only tells the new rule apart from the other rules of the form until it is saved. It is not the
+     * identifier of a row of the data source, and it may well be the one of a rule of another connector: what
+     * makes a rule new is its {@link RuleModel#TAG_ADDED} tag, never its identifier.
+     *
+     * @return an identifier that is unique among the rules of this connector
      */
     private int getTemporaryRuleId() {
         int maxRuleId = 0;
@@ -592,6 +594,91 @@ public class ConnectorModel extends PluginItemModel {
         }
 
         return maxRuleId + 1;
+    }
+
+
+
+    /**
+     * Obtains the identifiers of the submitted rules that are not rules of this connector.
+     *
+     * A rule that has just been added carries a temporary identifier, which is not looked at here. Any other
+     * identifier must be one of the rules that this connector holds in the data source. When it is not, the
+     * submitted data cannot be trusted: it has either been tampered with, or the browser has filled the form with
+     * a value belonging to another connector (issue #428).
+     *
+     * @param domainConnector the data object for this connector
+     * @return the identifiers that do not belong to this connector, empty if the submitted rules are consistent
+     */
+    public final Integer[] getForeignRuleIds(final Connector domainConnector) {
+
+        if (domainConnector == null) {
+            throw new IllegalArgumentException("The connector data object cannot be null.");
+        }
+
+        return this.getForeignRuleIds(domainConnector.getRulesCollection());
+    }
+
+
+
+    /**
+     * Obtains the identifiers of the submitted rules that cannot be, this connector not existing yet.
+     *
+     * A connector that is being created holds no rule, so no submitted rule can claim an identifier.
+     *
+     * @return the identifiers that no rule can carry here, empty if the submitted rules are consistent
+     */
+    public final Integer[] getForeignRuleIds() {
+        return this.getForeignRuleIds((Collection<Rule>) null);
+    }
+
+
+
+    /**
+     * Obtains the identifiers of the submitted rules that are none of the rules the connector holds.
+     *
+     * @param rulesInDataSource the rules that the connector holds, which may be null
+     * @return the identifiers that do not belong to the connector
+     */
+    private Integer[] getForeignRuleIds(final Collection<Rule> rulesInDataSource) {
+        final List<Integer> foreignRuleIds = new ArrayList<>();
+
+        for (RuleModel ruleModel : this.rules) {
+
+            if (ruleModel.isNew()) {
+                continue;
+            }
+
+            if (!ConnectorModel.containsRule(rulesInDataSource, ruleModel.getId())) {
+                foreignRuleIds.add(ruleModel.getId());
+            }
+        }
+
+        return foreignRuleIds.toArray(Integer[]::new);
+    }
+
+
+
+    /**
+     * Obtains whether a collection of rule data objects holds the one with a given identifier.
+     *
+     * @param domainRules the rule data objects to look into, which may be null
+     * @param ruleId      the identifier to look for
+     * @return <code>true</code> if one of those rules carries that identifier
+     */
+    private static boolean containsRule(final Collection<Rule> domainRules, final int ruleId) {
+
+        if (domainRules == null) {
+            return false;
+        }
+
+        for (Rule domainRule : domainRules) {
+
+            if (domainRule.getId() != null && domainRule.getId() == ruleId) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
 

--- a/extract/src/main/java/ch/asit_asso/extract/web/model/RuleModel.java
+++ b/extract/src/main/java/ch/asit_asso/extract/web/model/RuleModel.java
@@ -182,6 +182,26 @@ public class RuleModel {
 
 
     /**
+     * Obtains whether this rule has yet to be created in the data source.
+     *
+     * A rule that has just been added through the interface carries the identifier that the form gave it to tell
+     * it apart from the other blocks of the page. That identifier is not the one of a row of the data source, and
+     * it must never be used to fetch one (issue #428).
+     *
+     * The tag is the only thing that says so. An identifier is not enough to tell a new rule from an existing one,
+     * and it must not be: a submission carrying an untagged rule whose identifier is unknown, missing or negative
+     * has to be refused rather than turned into a new rule, or the check on the submitted identifiers could be
+     * walked around by sending an invalid one.
+     *
+     * @return <code>true</code> if this rule does not exist in the data source yet
+     */
+    public final boolean isNew() {
+        return RuleModel.TAG_ADDED.equals(this.getTag());
+    }
+
+
+
+    /**
      * Obtains the expression that the requests must match.
      *
      * @return the string expression

--- a/extract/src/main/java/ch/asit_asso/extract/web/validators/RuleValidator.java
+++ b/extract/src/main/java/ch/asit_asso/extract/web/validators/RuleValidator.java
@@ -55,7 +55,7 @@ public class RuleValidator extends BaseValidator {
         RuleModel rule = (RuleModel) target;
 
         if (rule.getProcessId() <= 0) {
-            errors.rejectValue("idProcess", "connectorDetails.errors.rule.process.undefined");
+            errors.rejectValue("processId", "connectorDetails.errors.rule.process.undefined");
         }
     }
 

--- a/extract/src/main/resources/messages_de.properties
+++ b/extract/src/main/resources/messages_de.properties
@@ -144,6 +144,7 @@ connectorDetails.errors.maxRetries.tooLarge=Die Anzahl der Importversuche darf n
 connectorDetails.errors.name.empty=Der Name darf nicht leer sein.
 connectorDetails.errors.rule.text.empty=Der Text der Regel ist obligatorisch.
 connectorDetails.errors.rule.process.undefined=Bitte weisen Sie der Regel eine Verarbeitung zu
+connectorDetails.errors.rule.foreign=Die gesendeten Daten verweisen auf eine Regel, die nicht zu diesem Konnektor gehört. Es wurde nichts gespeichert. Laden Sie die Seite neu und versuchen Sie es erneut.
 connectorDetails.fields.active.label=Aktiv?
 connectorDetails.fields.active.no=Nein
 connectorDetails.fields.active.yes=Ja

--- a/extract/src/main/resources/messages_en.properties
+++ b/extract/src/main/resources/messages_en.properties
@@ -142,6 +142,7 @@ connectorDetails.errors.maxRetries.tooLarge=The number of import attempts cannot
 connectorDetails.errors.name.empty=The name must not be empty.
 connectorDetails.errors.rule.text.empty=The rule text is required.
 connectorDetails.errors.rule.process.undefined=Please associate a process with the rule
+connectorDetails.errors.rule.foreign=The submitted data refers to a rule that does not belong to this connector. Nothing has been saved. Reload the page and try again.
 connectorDetails.fields.active.label=Active?
 connectorDetails.fields.active.no=No
 connectorDetails.fields.active.yes=Yes

--- a/extract/src/main/resources/messages_fr.properties
+++ b/extract/src/main/resources/messages_fr.properties
@@ -142,6 +142,7 @@ connectorDetails.errors.maxRetries.tooLarge=Le nombre de tentatives d'import ne 
 connectorDetails.errors.name.empty=Le nom ne doit pas \u00eatre vide.
 connectorDetails.errors.rule.text.empty=Le texte de la r\u00e8gle est obligatoire.
 connectorDetails.errors.rule.process.undefined=Veuillez associer un traitement \u00e0 la r\u00e8gle
+connectorDetails.errors.rule.foreign=Les donn\u00e9es envoy\u00e9es font r\u00e9f\u00e9rence \u00e0 une r\u00e8gle qui n'appartient pas \u00e0 ce connecteur. Rien n'a \u00e9t\u00e9 enregistr\u00e9. Rechargez la page et recommencez.
 connectorDetails.fields.active.label=Actif\u00a0?
 connectorDetails.fields.active.no=Non
 connectorDetails.fields.active.yes=Oui

--- a/extract/src/test/java/ch/asit_asso/extract/integration/connectors/ConnectorRuleOwnershipIntegrationTest.java
+++ b/extract/src/test/java/ch/asit_asso/extract/integration/connectors/ConnectorRuleOwnershipIntegrationTest.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright (C) 2026 asit-asso
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.asit_asso.extract.integration.connectors;
+
+import java.util.ArrayList;
+import ch.asit_asso.extract.domain.Connector;
+import ch.asit_asso.extract.domain.Process;
+import ch.asit_asso.extract.domain.Rule;
+import ch.asit_asso.extract.integration.DatabaseTestHelper;
+import ch.asit_asso.extract.integration.WithMockApplicationUser;
+import ch.asit_asso.extract.persistence.ConnectorsRepository;
+import ch.asit_asso.extract.persistence.ProcessesRepository;
+import ch.asit_asso.extract.persistence.RulesRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for the rules written when a connector is saved (issue #428).
+ *
+ * Saving a connector used to write into whichever rule carried the identifier that the form sent, wherever that
+ * rule lived, and to move it to the edited connector on the way. The connector it came from lost it without any
+ * sign, and the rule of the edited connector that the block stood for was deleted as a leftover: one save
+ * destroyed two rules.
+ *
+ * These tests run the real controller against a real PostgreSQL, and assert on the other connector, which must
+ * come out of the save exactly as it went in.
+ *
+ * @author Bruno Alves
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Tag("integration")
+@DisplayName("Connector Rule Ownership Integration Tests (issue #428)")
+class ConnectorRuleOwnershipIntegrationTest {
+
+    /**
+     * Prefixes the seeded values, so that they cannot collide with the test data set.
+     */
+    private static final String MARKER = "ZZ428";
+
+    /**
+     * The criteria that the untouched rule must still hold.
+     */
+    private static final String OTHER_CRITERIA = "orderlabel == \"ZZ428-other\"";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ConnectorsRepository connectorsRepository;
+
+    @Autowired
+    private ProcessesRepository processesRepository;
+
+    @Autowired
+    private RulesRepository rulesRepository;
+
+    @Autowired
+    private DatabaseTestHelper dbHelper;
+
+
+
+    @Nested
+    @DisplayName("1. Submitting a rule that belongs to another connector")
+    class ForeignRuleTests {
+
+        @Test
+        @DisplayName("1.1 - The save is refused, the other connector keeps its rule and this one keeps its own")
+        @WithMockApplicationUser(username = "admin", userId = 2, role = "ADMIN")
+        @Transactional
+        void aForeignRuleIdentifierIsRefused() throws Exception {
+            final Process domainProcess = ConnectorRuleOwnershipIntegrationTest.this.process();
+            final Connector otherConnector = ConnectorRuleOwnershipIntegrationTest.this.connector("other");
+            final Rule otherRule = ConnectorRuleOwnershipIntegrationTest.this.rule(otherConnector, domainProcess,
+                                                                                  ConnectorRuleOwnershipIntegrationTest.OTHER_CRITERIA);
+            final Connector editedConnector = ConnectorRuleOwnershipIntegrationTest.this.connector("edited");
+            final Rule ownRule = ConnectorRuleOwnershipIntegrationTest.this.rule(editedConnector, domainProcess,
+                                                                                "orderlabel == \"ZZ428-own\"");
+
+            ConnectorRuleOwnershipIntegrationTest.this.mockMvc.perform(
+                    ConnectorRuleOwnershipIntegrationTest.this.saveWithRule(editedConnector, otherRule.getId(),
+                                                                           domainProcess.getId(), false))
+                                                              .andExpect(status().isOk());
+
+            final Rule reloadedOtherRule
+                    = ConnectorRuleOwnershipIntegrationTest.this.rulesRepository.findById(otherRule.getId())
+                                                                               .orElseThrow();
+            assertEquals(otherConnector.getId(), reloadedOtherRule.getConnector().getId(),
+                         "The rule of the other connector has been moved.");
+            assertEquals(ConnectorRuleOwnershipIntegrationTest.OTHER_CRITERIA, reloadedOtherRule.getRule(),
+                         "The rule of the other connector lost its criteria.");
+            assertEquals("orderlabel == \"ZZ428-own\"",
+                         ConnectorRuleOwnershipIntegrationTest.this.rulesRepository.findById(ownRule.getId())
+                                                                                  .orElseThrow().getRule(),
+                         "The rule of the edited connector has been touched.");
+        }
+
+
+
+        @Test
+        @DisplayName("1.2 - A rule identifier that exists nowhere is refused instead of failing")
+        @WithMockApplicationUser(username = "admin", userId = 2, role = "ADMIN")
+        @Transactional
+        void anUnknownRuleIdentifierIsRefused() throws Exception {
+            final Process domainProcess = ConnectorRuleOwnershipIntegrationTest.this.process();
+            final Connector editedConnector = ConnectorRuleOwnershipIntegrationTest.this.connector("edited");
+            final Rule ownRule = ConnectorRuleOwnershipIntegrationTest.this.rule(editedConnector, domainProcess,
+                                                                                "orderlabel == \"ZZ428-own\"");
+
+            ConnectorRuleOwnershipIntegrationTest.this.mockMvc.perform(
+                    ConnectorRuleOwnershipIntegrationTest.this.saveWithRule(editedConnector, 999999,
+                                                                           domainProcess.getId(), false))
+                                                              .andExpect(status().isOk());
+
+            assertEquals("orderlabel == \"ZZ428-own\"",
+                         ConnectorRuleOwnershipIntegrationTest.this.rulesRepository.findById(ownRule.getId())
+                                                                                  .orElseThrow().getRule(),
+                         "The rule of the edited connector has been touched.");
+        }
+
+
+
+        @Test
+        @DisplayName("1.3 - Creating a connector with a rule that claims an identifier writes nothing at all")
+        @WithMockApplicationUser(username = "admin", userId = 2, role = "ADMIN")
+        @Transactional
+        void aForeignRuleIdentifierIsRefusedOnCreation() throws Exception {
+            final Process domainProcess = ConnectorRuleOwnershipIntegrationTest.this.process();
+            final Connector otherConnector = ConnectorRuleOwnershipIntegrationTest.this.connector("other");
+            final Rule otherRule = ConnectorRuleOwnershipIntegrationTest.this.rule(otherConnector, domainProcess,
+                                                                                  ConnectorRuleOwnershipIntegrationTest.OTHER_CRITERIA);
+            final long connectorsBefore
+                    = ConnectorRuleOwnershipIntegrationTest.this.connectorsRepository.count();
+
+            ConnectorRuleOwnershipIntegrationTest.this.mockMvc.perform(
+                    ConnectorRuleOwnershipIntegrationTest.this.createWithRule(otherRule.getId(),
+                                                                             domainProcess.getId()))
+                                                              .andExpect(status().isOk());
+
+            assertEquals(connectorsBefore,
+                         ConnectorRuleOwnershipIntegrationTest.this.connectorsRepository.count(),
+                         "No connector must have been created.");
+            final Rule reloadedOtherRule
+                    = ConnectorRuleOwnershipIntegrationTest.this.rulesRepository.findById(otherRule.getId())
+                                                                               .orElseThrow();
+            assertEquals(otherConnector.getId(), reloadedOtherRule.getConnector().getId(),
+                         "The rule of the other connector has been moved.");
+        }
+    }
+
+
+
+    @Nested
+    @DisplayName("2. Adding a rule")
+    class AddedRuleTests {
+
+        @Test
+        @DisplayName("2.1 - A rule added with the identifier of another connector's rule leaves that rule alone")
+        @WithMockApplicationUser(username = "admin", userId = 2, role = "ADMIN")
+        @Transactional
+        void anAddedRuleDoesNotOverwriteTheRuleOfAnotherConnector() throws Exception {
+            final Process domainProcess = ConnectorRuleOwnershipIntegrationTest.this.process();
+            final Connector otherConnector = ConnectorRuleOwnershipIntegrationTest.this.connector("other");
+            final Rule otherRule = ConnectorRuleOwnershipIntegrationTest.this.rule(otherConnector, domainProcess,
+                                                                                  ConnectorRuleOwnershipIntegrationTest.OTHER_CRITERIA);
+            final Connector editedConnector = ConnectorRuleOwnershipIntegrationTest.this.connector("edited");
+
+            ConnectorRuleOwnershipIntegrationTest.this.mockMvc.perform(
+                    ConnectorRuleOwnershipIntegrationTest.this.saveWithRule(editedConnector, otherRule.getId(),
+                                                                           domainProcess.getId(), true))
+                                                              .andExpect(status().is3xxRedirection());
+
+            final Rule reloadedOtherRule
+                    = ConnectorRuleOwnershipIntegrationTest.this.rulesRepository.findById(otherRule.getId())
+                                                                               .orElseThrow();
+            assertEquals(otherConnector.getId(), reloadedOtherRule.getConnector().getId(),
+                         "The rule of the other connector has been moved.");
+            assertEquals(ConnectorRuleOwnershipIntegrationTest.OTHER_CRITERIA, reloadedOtherRule.getRule(),
+                         "The rule of the other connector lost its criteria.");
+            final java.util.List<Rule> savedRules
+                    = ConnectorRuleOwnershipIntegrationTest.this.rulesRepository
+                            .findByConnectorOrderByPosition(editedConnector);
+            assertEquals(1, savedRules.size(), "The edited connector must have got its new rule.");
+            assertNotEquals(otherRule.getId(), savedRules.get(0).getId(),
+                            "The new rule must have an identifier of its own.");
+        }
+    }
+
+
+
+    /**
+     * Creates the process that the rules point to.
+     *
+     * @return the process data object
+     */
+    private Process process() {
+        final Process domainProcess = new Process();
+        domainProcess.setName(ConnectorRuleOwnershipIntegrationTest.MARKER + " process");
+        domainProcess.setTasksCollection(new ArrayList<>());
+        domainProcess.setUsersCollection(new ArrayList<>());
+        domainProcess.setUserGroupsCollection(new ArrayList<>());
+
+        return this.processesRepository.save(domainProcess);
+    }
+
+
+
+    /**
+     * Creates a connector that holds no rule.
+     *
+     * The collection of rules is set even though it is empty, because a connector that has just been persisted
+     * carries a null one until it is read again, whereas the application always works on connectors that it has
+     * loaded.
+     *
+     * @param nameSuffix what tells this connector apart from the other ones of the test
+     * @return the connector data object
+     */
+    private Connector connector(final String nameSuffix) {
+        final int connectorId = this.dbHelper.createTestConnector(
+                String.format("%s %s", ConnectorRuleOwnershipIntegrationTest.MARKER, nameSuffix));
+        final Connector domainConnector = this.connectorsRepository.findById(connectorId).orElseThrow();
+
+        if (domainConnector.getRulesCollection() == null) {
+            domainConnector.setRulesCollection(new ArrayList<>());
+        }
+
+        return domainConnector;
+    }
+
+
+
+    /**
+     * Creates a rule and adds it to a connector.
+     *
+     * @param domainConnector the connector that the rule belongs to
+     * @param domainProcess   the process that the rule points to
+     * @param criteria        the expression that the requests must match
+     * @return the rule data object
+     */
+    private Rule rule(final Connector domainConnector, final Process domainProcess, final String criteria) {
+        final Rule domainRule = new Rule();
+        domainRule.setConnector(domainConnector);
+        domainRule.setProcess(domainProcess);
+        domainRule.setRule(criteria);
+        domainRule.setActive(true);
+        domainRule.setPosition(domainConnector.getRulesCollection().size() + 1);
+        final Rule savedRule = this.rulesRepository.save(domainRule);
+        domainConnector.getRulesCollection().add(savedRule);
+
+        return savedRule;
+    }
+
+
+
+    /**
+     * Builds the submission of a connector holding a single rule that carries a given identifier.
+     *
+     * @param editedConnector the connector being saved
+     * @param ruleId          the identifier that the rule block carries
+     * @param processId       the process that the rule points to
+     * @param added           <code>true</code> to tag the rule as one that the interface has just added
+     * @return the request to perform
+     */
+    private MockHttpServletRequestBuilder saveWithRule(final Connector editedConnector, final int ruleId,
+            final int processId, final boolean added) {
+        return this.withConnectorFields(post("/connectors/{id}", editedConnector.getId()),
+                                        editedConnector.getName())
+                .param("id", String.valueOf(editedConnector.getId()))
+                .param("rules[0].id", String.valueOf(ruleId))
+                .param("rules[0].tag", added ? "ADDED" : "")
+                .param("rules[0].position", "1")
+                .param("rules[0].connectorId", String.valueOf(editedConnector.getId()))
+                .param("rules[0].rule", "orderlabel == \"" + ConnectorRuleOwnershipIntegrationTest.MARKER + "\"")
+                .param("rules[0].processId", String.valueOf(processId))
+                .param("rules[0].active", "1");
+    }
+
+
+
+    /**
+     * Builds the creation of a connector holding a single rule that claims a given identifier.
+     *
+     * @param ruleId    the identifier that the rule block carries
+     * @param processId the process that the rule points to
+     * @return the request to perform
+     */
+    private MockHttpServletRequestBuilder createWithRule(final int ruleId, final int processId) {
+        return this.withConnectorFields(post("/connectors/add"),
+                                        ConnectorRuleOwnershipIntegrationTest.MARKER + " created")
+                .param("id", "0")
+                .param("rules[0].id", String.valueOf(ruleId))
+                .param("rules[0].tag", "")
+                .param("rules[0].position", "1")
+                .param("rules[0].connectorId", "0")
+                .param("rules[0].rule", "orderlabel == \"" + ConnectorRuleOwnershipIntegrationTest.MARKER + "\"")
+                .param("rules[0].processId", String.valueOf(processId))
+                .param("rules[0].active", "1");
+    }
+
+
+
+    /**
+     * Adds the fields that every connector submission carries.
+     *
+     * @param request the request being built
+     * @param name    the name of the connector
+     * @return the request, with the connector fields set
+     */
+    private MockHttpServletRequestBuilder withConnectorFields(final MockHttpServletRequestBuilder request,
+            final String name) {
+        return request.with(csrf())
+                .param("name", name)
+                .param("typeCode", "test")
+                .param("typeLabel", "Test Connector")
+                .param("importFrequency", "240")
+                .param("maximumRetries", "0")
+                .param("active", "false");
+    }
+}

--- a/extract/src/test/java/ch/asit_asso/extract/unit/web/model/RuleOwnershipTest.java
+++ b/extract/src/test/java/ch/asit_asso/extract/unit/web/model/RuleOwnershipTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2026 asit-asso
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ch.asit_asso.extract.unit.web.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import ch.asit_asso.extract.domain.Connector;
+import ch.asit_asso.extract.domain.Rule;
+import ch.asit_asso.extract.web.model.ConnectorModel;
+import ch.asit_asso.extract.web.model.RuleModel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests that saving a connector cannot write into a rule of another connector (issue #428).
+ *
+ * The identifier that the form carries for a rule is not trustworthy: a rule added through the interface gets a
+ * temporary identifier computed from the rules of the form, and the browser can restore a value of its own into a
+ * field of the same name, the forms of two connectors being identical. Only the rules that the edited connector
+ * holds may be written to, and what makes a rule new is its tag, never its identifier.
+ *
+ * @author Bruno Alves
+ */
+@DisplayName("Rule Ownership Tests (issue #428)")
+class RuleOwnershipTest {
+
+    /**
+     * The identifier of the rule that belongs to another connector.
+     */
+    private static final int FOREIGN_RULE_ID = 1;
+
+
+
+    @Nested
+    @DisplayName("1. What makes a rule new")
+    class NewRuleTests {
+
+        @Test
+        @DisplayName("1.1 - A rule tagged as added is new, whatever its identifier")
+        void aTaggedRuleIsNew() {
+            final RuleModel ruleModel = new RuleModel();
+            ruleModel.setTag(RuleModel.TAG_ADDED);
+            ruleModel.setId(RuleOwnershipTest.FOREIGN_RULE_ID);
+
+            assertTrue(ruleModel.isNew(), "A rule carrying the added tag must be treated as a new one.");
+        }
+
+
+
+        @Test
+        @DisplayName("1.2 - An untagged rule is not new, even without a usable identifier")
+        void anUntaggedRuleIsNotNew() {
+            final RuleModel withoutId = new RuleModel();
+            final RuleModel withNegativeId = new RuleModel();
+            withNegativeId.setId(-1);
+
+            assertFalse(withoutId.isNew(), "An untagged rule must not be taken for a new one because its"
+                    + " identifier is missing: the submission has to be refused instead.");
+            assertFalse(withNegativeId.isNew(), "An untagged rule must not be taken for a new one because its"
+                    + " identifier is invalid, or the check on the submitted identifiers could be walked around.");
+        }
+    }
+
+
+
+    @Nested
+    @DisplayName("2. Checking the submitted rules")
+    class ForeignRuleIdsTests {
+
+        @Test
+        @DisplayName("2.1 - A submitted rule that belongs to another connector is reported")
+        void aForeignRuleIsReported() {
+            final Connector editedConnector = RuleOwnershipTest.this.connector(12);
+            final ConnectorModel connectorModel
+                    = RuleOwnershipTest.this.connectorModel(RuleOwnershipTest.FOREIGN_RULE_ID);
+
+            assertArrayEquals(new Integer[]{RuleOwnershipTest.FOREIGN_RULE_ID},
+                              connectorModel.getForeignRuleIds(editedConnector));
+        }
+
+
+
+        @Test
+        @DisplayName("2.2 - Rules that all belong to the connector are accepted")
+        void ownRulesAreAccepted() {
+            final Connector editedConnector = RuleOwnershipTest.this.connector(12);
+            RuleOwnershipTest.this.rule(15, editedConnector);
+            RuleOwnershipTest.this.rule(16, editedConnector);
+            final ConnectorModel connectorModel = RuleOwnershipTest.this.connectorModel(15, 16);
+
+            assertArrayEquals(new Integer[]{}, connectorModel.getForeignRuleIds(editedConnector));
+        }
+
+
+
+        @Test
+        @DisplayName("2.3 - The temporary identifier of an added rule is not reported")
+        void anAddedRuleIsNotReported() {
+            final Connector editedConnector = RuleOwnershipTest.this.connector(12);
+            final ConnectorModel connectorModel = new ConnectorModel();
+            final RuleModel addedRule = new RuleModel();
+            addedRule.setTag(RuleModel.TAG_ADDED);
+            addedRule.setId(RuleOwnershipTest.FOREIGN_RULE_ID);
+            connectorModel.setRules(new RuleModel[]{addedRule});
+
+            assertArrayEquals(new Integer[]{}, connectorModel.getForeignRuleIds(editedConnector));
+        }
+
+
+
+        @Test
+        @DisplayName("2.4 - An untagged rule with an invalid identifier is reported, not created")
+        void anUntaggedRuleWithAnInvalidIdentifierIsReported() {
+            final Connector editedConnector = RuleOwnershipTest.this.connector(12);
+            final ConnectorModel connectorModel = RuleOwnershipTest.this.connectorModel(-1);
+
+            assertArrayEquals(new Integer[]{-1}, connectorModel.getForeignRuleIds(editedConnector));
+        }
+
+
+
+        @Test
+        @DisplayName("2.5 - A rule claiming an identifier is reported when the connector is being created")
+        void aRuleWithAnIdentifierIsReportedOnCreation() {
+            final ConnectorModel connectorModel
+                    = RuleOwnershipTest.this.connectorModel(RuleOwnershipTest.FOREIGN_RULE_ID);
+
+            assertArrayEquals(new Integer[]{RuleOwnershipTest.FOREIGN_RULE_ID},
+                              connectorModel.getForeignRuleIds());
+        }
+
+
+
+        @Test
+        @DisplayName("2.6 - The rules of a connector being created are accepted when they are all new")
+        void addedRulesAreAcceptedOnCreation() {
+            final ConnectorModel connectorModel = new ConnectorModel();
+            final RuleModel addedRule = new RuleModel();
+            addedRule.setTag(RuleModel.TAG_ADDED);
+            addedRule.setId(RuleOwnershipTest.FOREIGN_RULE_ID);
+            connectorModel.setRules(new RuleModel[]{addedRule});
+
+            assertArrayEquals(new Integer[]{}, connectorModel.getForeignRuleIds());
+        }
+    }
+
+
+
+    /**
+     * Makes a connector data object that holds no rule yet.
+     *
+     * @param connectorId the identifier of the connector
+     * @return the connector data object
+     */
+    private Connector connector(final int connectorId) {
+        final Connector domainConnector = new Connector(connectorId);
+        domainConnector.setRulesCollection(new ArrayList<>());
+
+        return domainConnector;
+    }
+
+
+
+    /**
+     * Makes a rule and adds it to a connector.
+     *
+     * @param ruleId          the identifier of the rule
+     * @param domainConnector the connector that the rule is part of
+     * @return the rule data object
+     */
+    private Rule rule(final int ruleId, final Connector domainConnector) {
+        final Rule domainRule = new Rule(ruleId);
+        domainRule.setConnector(domainConnector);
+        domainRule.setPosition(domainConnector.getRulesCollection().size() + 1);
+        domainConnector.getRulesCollection().add(domainRule);
+
+        return domainRule;
+    }
+
+
+
+    /**
+     * Makes the model of a connector that submits untagged rules with the given identifiers.
+     *
+     * @param ruleIds the identifiers carried by the submitted rules
+     * @return the connector model
+     */
+    private ConnectorModel connectorModel(final int... ruleIds) {
+        final ConnectorModel connectorModel = new ConnectorModel();
+        final List<RuleModel> rules = new ArrayList<>();
+
+        for (int ruleId : ruleIds) {
+            final RuleModel ruleModel = new RuleModel();
+            ruleModel.setId(ruleId);
+            rules.add(ruleModel);
+        }
+
+        connectorModel.setRules(rules.toArray(RuleModel[]::new));
+
+        return connectorModel;
+    }
+}


### PR DESCRIPTION
Corrige #428. Jumeau de #427, côté connecteurs.

## Ce que la reproduction a montré

Pire que ce que j'avais écrit dans l'issue. **Une seule sauvegarde détruit deux règles.**

Décor : connecteur « Bouchon » avec sa règle 1, connecteur B avec sa règle 15. Un bloc non tagué de B portant l'id 1 :

| Avant | Après |
| --- | --- |
| règle 1, connecteur Bouchon, `orderlabel == "AAA"` | règle 1 **déplacée** sur le connecteur B, critère écrasé |
| règle 15, connecteur B | **supprimée** |
| | Bouchon se retrouve sans aucune règle |

La règle n'est pas copiée, elle est déplacée : `RuleModel.updateDomainRule()` appelle `setConnector(domainConnector)`. Le connecteur d'origine perd silencieusement la règle qui aiguillait une partie de ses commandes, et la règle propre du connecteur édité est supprimée comme reliquat, n'étant plus dans les ids soumis.

## Deux autres défauts trouvés sur le même écran

Les deux répondaient une 500 là où un message était dû :

1. **Id de règle inexistant** → `UnsupportedOperationException("Impossible to move a rule that does not exist")`, après que les règles déjà traitées par la boucle ont été écrites.
2. **Règle sans traitement** → `RuleValidator` rejetait le champ `idProcess` alors que la propriété s'appelle `processId`. Spring renvoyait `NotReadablePropertyException`. Autrement dit : laisser le traitement d'une règle vide, une simple erreur de saisie, mettait la page en 500 au lieu d'afficher « Veuillez associer un traitement à la règle ».

## Pourquoi ça ne s'était pas vu plus souvent

Contrairement aux tâches, `updateConnectorRules()` respectait bien le tag `ADDED` : ajouter une règle par l'interface a toujours fonctionné, quel que soit l'id inventé. Ce qui restait exposé, c'est un bloc **non tagué** portant un id étranger — formulaire périmé, navigateur qui restaure une valeur dans un champ de même nom (les formulaires de deux connecteurs sont identiques), ou requête forgée.

## Ce que fait la PR

| Fichier | Changement |
| --- | --- |
| `RuleModel.java` | Nouveau `isNew()`, qui lit le tag et **rien d'autre**. Un id ne suffit pas à distinguer une règle neuve, et ne doit pas suffire : une règle non taguée dont l'id est absent, négatif ou inconnu est refusée et non créée, sinon le contrôle ci-dessous se contourne en envoyant un id invalide |
| `ConnectorModel.java` | Nouveau `getForeignRuleIds()`, en deux formes : contre les règles du connecteur à la mise à jour, contre rien à la création puisqu'un connecteur en cours de création n'a aucune règle. Commentaire de `getTemporaryRuleId()` corrigé — il affirmait que la valeur était ignorée à la sauvegarde, ce qui était le bug |
| `ConnectorsController.java` | La règle est cherchée parmi celles du connecteur sauvegardé, jamais dans toute la table. La soumission est contrôlée avant toute écriture, à la mise à jour **et** à la création. La création ne va plus chercher aucune règle par id |
| `RuleValidator.java` | Rejette `processId`, le nom que la propriété porte réellement |
| `messages_fr/de/en` | Nouvelle clé `connectorDetails.errors.rule.foreign` |

## Vérifié au navigateur, avant et après

| Scénario | Avant | Après |
| --- | --- | --- |
| Règle taguée dont l'id temporaire entre en collision | créée correctement | créée correctement |
| Bloc non tagué portant l'id d'une règle étrangère | règle déplacée + règle propre supprimée | refusé, message, **rien** en base |
| Id de règle inexistant | 500 | refusé, message |
| Règle sans traitement | 500 | « Veuillez associer un traitement à la règle » |
| Modifier une règle | ok | ok |
| Réordonner par glisser-déposer | ok | ok |
| Supprimer une règle | ok | ok |

## Tests

`RuleOwnershipTest` (unitaire, 8 cas) et `ConnectorRuleOwnershipIntegrationTest` (intégration, vrai PostgreSQL, 4 cas).

Passés contre le code non corrigé, **trois des quatre cas d'intégration tombent** : deux sauvegardes qui passent là où un refus était dû, et l'id inconnu qui renvoie 500. Le quatrième garde le chemin du tag, déjà correct avant.

Suites complètes sous JDK 17 : **1405 unitaires**, **498 d'intégration**, 0 échec.

## Repérer les installations déjà touchées

Un connecteur qui a perdu une règle ne signale rien, et une tâche laissée avec les réglages d'un autre plugin non plus quand ce plugin n'a pas de paramètre obligatoire. Les trois traces à chercher sont décrites dans `changelog/v2.4/ISSUE_428.md` : tâches partageant une position, tâches portant les paramètres d'un autre plugin, connecteurs sans aucune règle.

Les requêtes correspondantes ne sont **pas** dans cette PR : elles déduisent le comportement normal d'une installation donnée, ce sont des pistes et non des verdicts, et elles servent à qui répare une base, pas à ce correctif. Elles sont [postées sur l'issue](https://github.com/asit-asso/extract/issues/428#issuecomment-5494826195), avec leurs limites et l'avertissement sur la séquence partagée.

## Note de merge

La section de documentation atterrit dans « Rules Management », alors que #427 en ajoute une juste avant « Authentication ». Selon l'ordre de merge, un conflit léger sur `architecture.md` est possible ; les deux sections sont complémentaires et se référencent l'une l'autre.
